### PR TITLE
Refactor and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Tools
 poetry.lock
 .tox
+.coverage

--- a/mandible/h5_parser.py
+++ b/mandible/h5_parser.py
@@ -22,14 +22,18 @@ class H5parser(dict):
                     node_val = h5f[key][()]
                 except KeyError:
                     raise KeyError(key)
-                if isinstance(node_val, np.integer):
-                    node_val = int(node_val)
-                if isinstance(node_val, np.floating):
-                    node_val = float(node_val)
-                if isinstance(node_val, np.ndarray):
-                    node_val = node_val.tolist()
-                    if isinstance(node_val[0], bytes):
-                        node_val = [x.decode("utf-8") for x in node_val]
-                if isinstance(node_val, bytes):
-                    node_val = node_val.decode("utf-8")
-                self[key] = node_val
+                self[key] = normalize(node_val)
+
+
+def normalize(node_val):
+    if isinstance(node_val, np.integer):
+        return int(node_val)
+    if isinstance(node_val, np.floating):
+        return float(node_val)
+    if isinstance(node_val, np.ndarray):
+        value = node_val.tolist()
+        if isinstance(value[0], bytes):
+            value = [x.decode("utf-8") for x in value]
+        return value
+    if isinstance(node_val, bytes):
+        return node_val.decode("utf-8")

--- a/mandible/metadata_mapper/format.py
+++ b/mandible/metadata_mapper/format.py
@@ -1,7 +1,8 @@
 import contextlib
 import json
 from abc import ABC, abstractmethod
-from typing import IO, Any, ContextManager, Dict, Iterable
+from dataclasses import dataclass
+from typing import IO, Any, ClassVar, ContextManager, Dict, Iterable
 
 from ..h5_parser import normalize
 
@@ -24,8 +25,10 @@ class FormatError(Exception):
         return self.reason
 
 
+@dataclass
 class Format(ABC):
-    _SUBCLASSES: Dict[str, "Format"] = {}
+    # Registry boilerplate
+    _SUBCLASSES: ClassVar[Dict[str, "Format"]] = {}
 
     def __init_subclass__(cls):
         Format._SUBCLASSES[cls.__name__] = cls
@@ -34,6 +37,7 @@ class Format(ABC):
     def get_subclass(cls, name: str) -> "Format":
         return cls._SUBCLASSES[name]
 
+    # Begin class definition
     def get_values(self, file: IO[bytes], keys: Iterable[str]):
         with self._parse_data(file) as data:
             return {

--- a/mandible/metadata_mapper/source.py
+++ b/mandible/metadata_mapper/source.py
@@ -1,6 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Set
+from dataclasses import dataclass
+from typing import Any, Dict, Set
 
 from .context import Context
 from .format import Format
@@ -9,13 +10,14 @@ from .storage import Storage
 log = logging.getLogger(__name__)
 
 
+@dataclass
 class Source:
-    def __init__(self, storage: Storage, format: Format):
-        self.storage = storage
-        self.format = format
+    storage: Storage
+    format: Format
 
+    def __post_init__(self):
         self._keys: Set[str] = set()
-        self._values: Dict[str] = {}
+        self._values: Dict[str, Any] = {}
 
     def add_key(self, key: str):
         self._keys.add(key)
@@ -34,9 +36,6 @@ class Source:
 
     def get_value(self, key: str):
         return self._values[key]
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.storage}, {self.format})"
 
 
 class SourceProvider(ABC):

--- a/mandible/metadata_mapper/source.py
+++ b/mandible/metadata_mapper/source.py
@@ -70,7 +70,9 @@ class ConfigSourceProvider(SourceProvider):
         }
 
     def _get_storage(self, name: str, config: Dict) -> Storage:
-        cls = Storage.get_subclass(config["class"])
+        cls_name = config["class"]
+        cls = Storage.get_subclass(cls_name)
+
         name = config.get("name")
         name_match = config.get("name_match")
 
@@ -82,4 +84,5 @@ class ConfigSourceProvider(SourceProvider):
     def _get_format(self, config: Dict) -> Format:
         cls_name = config["class"]
         cls = Format.get_subclass(cls_name)
+
         return cls()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,11 @@ pytest = "^7.1.2"
 pytest-mock = "^3.8.2"
 
 
+[tool.pytest.ini_options]
+markers = [
+    "h5: requires the 'h5' extra to be installed",
+    "xml: requires the 'xml' extra to be installed",
+]
+
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ xml = ["lxml"]
 boto3 = "^1.18"
 moto = "^4.0.1"
 pytest = "^7.1.2"
+pytest-cov = "^4.0.0"
 pytest-mock = "^3.8.2"
 
 

--- a/tests/data/local_file.txt
+++ b/tests/data/local_file.txt
@@ -1,0 +1,1 @@
+Some local file content

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,0 +1,121 @@
+import io
+
+import h5py
+import pytest
+
+from mandible.metadata_mapper.format import H5, Format, FormatError, Json, Xml
+
+
+def test_registry():
+    assert Format.get_subclass("H5") is H5
+    assert Format.get_subclass("Json") is Json
+    assert Format.get_subclass("Xml") is Xml
+
+
+def test_registry_error():
+    with pytest.raises(KeyError):
+        Format.get_subclass("FooBarBaz")
+
+
+@pytest.mark.h5
+def test_h5():
+    file = io.BytesIO()
+    with h5py.File(file, "w") as f:
+        f["foo"] = "foo value"
+        f["bar"] = "bar value"
+        f["list"] = ["list", "value"]
+        nested = f.create_group("nested")
+        nested["qux"] = "qux nested value"
+
+    format = H5()
+
+    assert format.get_values(
+        file,
+        ["/foo", "bar", "list", "nested/qux"]
+    ) == {
+        "/foo": "foo value",
+        "bar": "bar value",
+        "list": ["list", "value"],
+        "nested/qux": "qux nested value"
+    }
+
+
+def test_h5_key_error():
+    file = io.BytesIO()
+    with h5py.File(file, "w"):
+        pass
+
+    format = H5()
+
+    with pytest.raises(FormatError, match="Key not found 'foo'"):
+        format.get_values(file, ["foo"])
+
+
+def test_json():
+    file = io.BytesIO(b"""
+    {
+        "foo": "foo value",
+        "bar": "bar value",
+        "list": ["list", "value"],
+        "nested": {
+            "qux": "qux nested value"
+        }
+    }
+    """)
+    format = Json()
+
+    assert format.get_values(
+        file,
+        ["foo", "bar", "list", "nested.qux"]
+    ) == {
+        "foo": "foo value",
+        "bar": "bar value",
+        "list": ["list", "value"],
+        "nested.qux": "qux nested value"
+    }
+
+
+def test_json_key_error():
+    file = io.BytesIO(b"{}")
+    format = Json()
+
+    with pytest.raises(FormatError, match="Key not found 'foo'"):
+        format.get_values(file, ["foo"])
+
+
+@pytest.mark.xml
+def test_xml():
+    file = io.BytesIO(b"""
+    <root>
+        <foo>foo value</foo>
+        <bar>bar value</bar>
+        <list>
+            <v>list</v>
+            <v>value</v>
+        </list>
+        <nested>
+            <qux>qux nested value</qux>
+        </nested>
+    </root>
+    """)
+    format = Xml()
+
+    # TODO(reweeden): Selecting lists is not supported
+    assert format.get_values(
+        file,
+        ["/root/foo", "./bar", "./list/v[2]", "./nested/qux"]
+    ) == {
+        "/root/foo": "foo value",
+        "./bar": "bar value",
+        "./list/v[2]": "value",
+        "./nested/qux": "qux nested value"
+    }
+
+
+def test_xml_key_error():
+    file = io.BytesIO(b"<root></root>")
+
+    format = Xml()
+
+    with pytest.raises(FormatError, match="Key not found 'foo'"):
+        format.get_values(file, ["foo"])

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,0 +1,48 @@
+import io
+from unittest import mock
+
+import pytest
+
+from mandible.metadata_mapper.context import Context
+from mandible.metadata_mapper.format import Format
+from mandible.metadata_mapper.source import Source
+from mandible.metadata_mapper.storage import Storage
+
+
+@pytest.fixture
+def mock_context():
+    return mock.create_autospec(Context)
+
+
+@pytest.fixture
+def mock_format():
+    return mock.create_autospec(Format)
+
+
+@pytest.fixture
+def mock_storage():
+    return mock.create_autospec(Storage)
+
+
+def test_source(mock_context, mock_format, mock_storage):
+    mock_storage.open_file.return_value = io.BytesIO(b"mock data")
+    mock_format.get_values.return_value = {
+        "foo": "foo value",
+        "bar": "bar value"
+    }
+
+    source = Source(
+        mock_storage,
+        mock_format
+    )
+
+    source.add_key("foo")
+    source.add_key("bar")
+
+    with pytest.raises(KeyError):
+        source.get_value("foo")
+
+    source.query_all_values(mock_context)
+
+    assert source.get_value("foo") == "foo value"
+    assert source.get_value("bar") == "bar value"

--- a/tests/test_source_provider.py
+++ b/tests/test_source_provider.py
@@ -1,0 +1,48 @@
+import pytest
+
+from mandible.metadata_mapper.format import Json, Xml
+from mandible.metadata_mapper.source import (
+    ConfigSourceProvider,
+    PySourceProvider,
+    Source,
+)
+from mandible.metadata_mapper.storage import LocalFile
+
+
+@pytest.fixture
+def sources():
+    return {
+        "json": Source(LocalFile(name="foo"), Json()),
+        "xml": Source(LocalFile(name="foo"), Xml())
+    }
+
+
+def test_py_source_provider(sources):
+    provider = PySourceProvider(sources)
+
+    assert provider.get_sources() == sources
+
+
+def test_config_source_provider(sources):
+    provider = ConfigSourceProvider({
+        "json": {
+            "storage": {
+                "class": "LocalFile",
+                "name": "foo"
+            },
+            "format": {
+                "class": "Json"
+            }
+        },
+        "xml": {
+            "storage": {
+                "class": "LocalFile",
+                "name": "foo"
+            },
+            "format": {
+                "class": "Xml"
+            }
+        }
+    })
+
+    assert provider.get_sources() == sources

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,86 @@
+import io
+
+import pytest
+
+from mandible.metadata_mapper.context import Context
+from mandible.metadata_mapper.storage import LocalFile, S3File, Storage
+
+
+def test_registry():
+    assert Storage.get_subclass("LocalFile") is LocalFile
+    assert Storage.get_subclass("S3File") is S3File
+
+
+def test_registry_error():
+    with pytest.raises(KeyError):
+        Storage.get_subclass("FooBarBaz")
+
+
+def test_local_file(data_path):
+    context = Context(
+        files={
+            "local_file": {
+                "path": str(data_path / "local_file.txt")
+            }
+        }
+    )
+    storage = LocalFile(name="local_file")
+
+    with storage.open_file(context) as f:
+        assert f.read() == b"Some local file content\n"
+
+
+def test_local_file_name_match(data_path):
+    context = Context(
+        files={
+            "local_file": {
+                "path": str(data_path / "local_file.txt")
+            }
+        }
+    )
+    storage = LocalFile(name_match="local_.*")
+
+    with storage.open_file(context) as f:
+        assert f.read() == b"Some local file content\n"
+
+
+def test_local_file_creation_error():
+    with pytest.raises(ValueError, match="You must provide"):
+        _ = LocalFile()
+    with pytest.raises(ValueError, match="You can't provide"):
+        _ = LocalFile(name="foo", name_match="foo")
+
+
+def test_local_file_name_error():
+    context = Context()
+    storage = LocalFile(name="foo.txt")
+
+    with pytest.raises(KeyError):
+        storage.open_file(context)
+
+
+def test_local_file_name_match_error():
+    context = Context()
+    storage = LocalFile(name_match="foo.*")
+
+    with pytest.raises(RuntimeError, match="No files matched pattern"):
+        storage.open_file(context)
+
+
+def test_s3_file(s3_resource):
+    bucket = s3_resource.Bucket("test-bucket")
+    bucket.create()
+    obj = bucket.Object("bucket_file.txt")
+    obj.upload_fileobj(io.BytesIO(b"Some remote file content\n"))
+
+    context = Context(
+        files={
+            "local_file": {
+                "s3uri": "s3://test-bucket/bucket_file.txt"
+            }
+        }
+    )
+    storage = S3File(name="local_file")
+
+    with storage.open_file(context) as f:
+        assert f.read() == b"Some remote file content\n"


### PR DESCRIPTION
We mostly just had integration tests and I wanted to add some unit tests as well. This also required me to do a little bit of refactoring like using dataclasses to generate `__eq__` methods for use in test assertions. I also tried to improve the error messages for the `Format` class to help with some test debugging.