### PR TITLE
Skip reading file if no keys will be queried

### DIFF
--- a/mandible/metadata_mapper/source.py
+++ b/mandible/metadata_mapper/source.py
@@ -23,6 +23,9 @@ class Source:
         self._keys.add(key)
 
     def query_all_values(self, context: Context):
+        if not self._keys:
+            return
+
         with self.storage.open_file(context) as file:
             keys = list(self._keys)
             new_values = self.format.get_values(file, keys)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.1.0"
+version = "0.1.1"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -46,3 +46,15 @@ def test_source(mock_context, mock_format, mock_storage):
 
     assert source.get_value("foo") == "foo value"
     assert source.get_value("bar") == "bar value"
+
+
+def test_source_query_no_keys(mock_context, mock_format, mock_storage):
+    source = Source(
+        mock_storage,
+        mock_format
+    )
+
+    source.query_all_values(mock_context)
+
+    mock_storage.open_file.assert_not_called()
+    mock_format.get_values.assert_not_called()


### PR DESCRIPTION
This is breaking the TEC injest because the JSON file is empty, however, it is being run through the json decoder even when the template has no references to the source. I'd like to be able to define a source and have it be essentially a NOOP if it is not used in the template.