### PR TITLE
Improved source filtering

### DIFF
--- a/mandible/internal/__init__.py
+++ b/mandible/internal/__init__.py
@@ -1,0 +1,5 @@
+from .types import Registry
+
+__all__ = (
+    "Registry",
+)

--- a/mandible/internal/types.py
+++ b/mandible/internal/types.py
@@ -1,0 +1,4 @@
+from typing import MutableMapping, TypeVar
+
+T = TypeVar("T")
+Registry = MutableMapping[str, T]

--- a/mandible/metadata_mapper/context.py
+++ b/mandible/metadata_mapper/context.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Any, Dict, List
 
 
 @dataclass
 class Context:
-    files: Dict[str, Dict] = field(default_factory=dict)
-    meta: Dict = field(default_factory=dict)
+    files: List[Dict[str, Any]] = field(default_factory=list)
+    meta: Dict[str, Any] = field(default_factory=dict)

--- a/mandible/metadata_mapper/format.py
+++ b/mandible/metadata_mapper/format.py
@@ -2,7 +2,7 @@ import contextlib
 import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import IO, Any, ClassVar, ContextManager, Dict, Iterable
+from typing import IO, Any, ContextManager, Dict, Iterable, Type
 
 from ..h5_parser import normalize
 
@@ -25,17 +25,14 @@ class FormatError(Exception):
         return self.reason
 
 
+FORMAT_REGISTRY: Dict[str, Type["Format"]] = {}
+
+
 @dataclass
 class Format(ABC):
     # Registry boilerplate
-    _SUBCLASSES: ClassVar[Dict[str, "Format"]] = {}
-
     def __init_subclass__(cls):
-        Format._SUBCLASSES[cls.__name__] = cls
-
-    @classmethod
-    def get_subclass(cls, name: str) -> "Format":
-        return cls._SUBCLASSES[name]
+        FORMAT_REGISTRY[cls.__name__] = cls
 
     # Begin class definition
     def get_values(self, file: IO[bytes], keys: Iterable[str]):

--- a/mandible/metadata_mapper/source.py
+++ b/mandible/metadata_mapper/source.py
@@ -1,13 +1,22 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, Set
+from typing import Any, Dict, Protocol, Set, Type, TypeVar
 
 from .context import Context
 from .format import Format
 from .storage import Storage
 
 log = logging.getLogger(__name__)
+
+
+T = TypeVar("T")
+
+
+class _Registry(Protocol[T]):
+    @classmethod
+    def get_subclass(cls, name: str) -> Type[T]:
+        ...
 
 
 @dataclass
@@ -64,28 +73,23 @@ class ConfigSourceProvider(SourceProvider):
         self.config = config
 
     def get_sources(self) -> Dict[str, Source]:
+        # TODO(reweeden): Catch errors and correlate to key
         return {
             key: Source(
-                storage=self._get_storage(key, config["storage"]),
-                format=self._get_format(config["format"])
+                storage=self._get_registered_class(Storage, config["storage"]),
+                format=self._get_registered_class(Format, config["format"])
             )
             for key, config in self.config.items()
         }
 
-    def _get_storage(self, name: str, config: Dict) -> Storage:
+    def _get_registered_class(self, registry: _Registry[T], config: Dict) -> T:
         cls_name = config["class"]
-        cls = Storage.get_subclass(cls_name)
+        cls = registry.get_subclass(cls_name)
 
-        name = config.get("name")
-        name_match = config.get("name_match")
+        kwargs = {
+            k: v
+            for k, v in config.items()
+            if k != "class"
+        }
 
-        return cls(
-            name=name,
-            name_match=name_match
-        )
-
-    def _get_format(self, config: Dict) -> Format:
-        cls_name = config["class"]
-        cls = Format.get_subclass(cls_name)
-
-        return cls()
+        return cls(**kwargs)

--- a/mandible/metadata_mapper/storage.py
+++ b/mandible/metadata_mapper/storage.py
@@ -1,16 +1,21 @@
 import re
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import IO, ClassVar, Dict, Optional, Union
+from dataclasses import dataclass, field
+from typing import IO, Any, ClassVar, Dict
 
 import s3fs
 
 from .context import Context
 
 
+class StorageError(Exception):
+    pass
+
+
 @dataclass
 class Storage(ABC):
     # Registry boilerplate
+    # TODO(reweeden): Create Registry class?
     _SUBCLASSES: ClassVar[Dict[str, "Storage"]] = {}
 
     def __init_subclass__(cls):
@@ -21,36 +26,39 @@ class Storage(ABC):
         return cls._SUBCLASSES[name]
 
     # Begin class definition
-    name: Optional[str] = None
-    name_match: Optional[Union[str, re.Pattern]] = None
+    filters: Dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self):
-        if self.name is None and self.name_match is None:
-            raise ValueError(
-                "You must provide either a 'name' xor 'name_match' argument"
-            )
-        if self.name is not None and self.name_match is not None:
-            raise ValueError(
-                "You can't provide both a 'name' and 'name_match' argument"
-            )
+        self._compiled_filters = {
+            k: re.compile(v) if isinstance(v, str) else v
+            for k, v in self.filters.items()
+        }
 
     def open_file(self, context: Context) -> IO[bytes]:
-        if self.name is not None:
-            file = context.files[self.name]
-        elif self.name_match is not None:
-            if not isinstance(self.name_match, re.Pattern):
-                self.name_match = re.compile(self.name_match)
-
-            for file_name, file_info in context.files.items():
-                if self.name_match.match(file_name):
-                    file = file_info
-                    break
-            else:
-                raise RuntimeError(
-                    f"No files matched pattern '{self.name_match.pattern}'"
-                )
-
+        file = self.get_file_from_context(context)
         return self._open_file(file)
+
+    def get_file_from_context(self, context: Context) -> Dict[str, Any]:
+        """Return the file from the context which matches all filters."""
+        for info in context.files:
+            if self._matches_filters(info):
+                return info
+
+        raise StorageError(f"No files matched filters {self.filters}")
+
+    def _matches_filters(self, info: Dict[str, Any]) -> bool:
+        for key, pattern in self._compiled_filters.items():
+            if key not in info:
+                return False
+
+            value = info[key]
+            if isinstance(pattern, re.Pattern):
+                if not pattern.fullmatch(value):
+                    return False
+            elif value != pattern:
+                return False
+
+        return True
 
     @abstractmethod
     def _open_file(self, info: Dict) -> IO[bytes]:

--- a/mandible/metadata_mapper/storage.py
+++ b/mandible/metadata_mapper/storage.py
@@ -1,7 +1,7 @@
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import IO, Any, ClassVar, Dict
+from typing import IO, Any, Dict, Type
 
 import s3fs
 
@@ -12,18 +12,14 @@ class StorageError(Exception):
     pass
 
 
+STORAGE_REGISTRY: Dict[str, Type["Storage"]] = {}
+
+
 @dataclass
 class Storage(ABC):
     # Registry boilerplate
-    # TODO(reweeden): Create Registry class?
-    _SUBCLASSES: ClassVar[Dict[str, "Storage"]] = {}
-
     def __init_subclass__(cls):
-        Storage._SUBCLASSES[cls.__name__] = cls
-
-    @classmethod
-    def get_subclass(cls, name: str) -> "Storage":
-        return cls._SUBCLASSES[name]
+        STORAGE_REGISTRY[cls.__name__] = cls
 
     # Begin class definition
     filters: Dict[str, str] = field(default_factory=dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.1.1"
+version = "0.2.0"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -3,18 +3,18 @@ import io
 import h5py
 import pytest
 
-from mandible.metadata_mapper.format import H5, Format, FormatError, Json, Xml
+from mandible.metadata_mapper.format import FORMAT_REGISTRY, H5, FormatError, Json, Xml
 
 
 def test_registry():
-    assert Format.get_subclass("H5") is H5
-    assert Format.get_subclass("Json") is Json
-    assert Format.get_subclass("Xml") is Xml
+    assert FORMAT_REGISTRY.get("H5") is H5
+    assert FORMAT_REGISTRY.get("Json") is Json
+    assert FORMAT_REGISTRY.get("Xml") is Xml
 
 
 def test_registry_error():
     with pytest.raises(KeyError):
-        Format.get_subclass("FooBarBaz")
+        FORMAT_REGISTRY["FooBarBaz"]
 
 
 @pytest.mark.h5

--- a/tests/test_metadata_mapper.py
+++ b/tests/test_metadata_mapper.py
@@ -20,7 +20,9 @@ def config():
             "fixed_name_file": {
                 "storage": {
                     "class": "LocalFile",
-                    "name": "fixed_name_file.json"
+                    "filters": {
+                        "name": r"fixed_name_file\.json"
+                    }
                 },
                 "format": {
                     "class": "Json",
@@ -29,7 +31,9 @@ def config():
             "name_match_file": {
                 "storage": {
                     "class": "LocalFile",
-                    "name_match": r".*match_me\.json"
+                    "filters": {
+                        "name": r".*match_me\.json"
+                    }
                 },
                 "format": {
                     "class": "Json"
@@ -38,7 +42,9 @@ def config():
             "fixed_xml_file": {
                 "storage": {
                     "class": "LocalFile",
-                    "name": "fixed_xml_file.xml"
+                    "filters": {
+                        "name": "fixed_xml_file.xml"
+                    }
                 },
                 "format": {
                     "class": "Xml"
@@ -85,20 +91,29 @@ def config():
 @pytest.fixture
 def context(data_path):
     return Context(
-        files={
-            "fixed_name_file.json": {
+        files=[
+            {
+                "name": "fixed_name_file.json",
                 "path": str(data_path / "fixed_name_file.json")
             },
-            "fixed_xml_file.xml": {
+            {
+                "name": "fixed_xml_file.xml",
                 "path": str(data_path / "fixed_xml_file.xml")
             },
-            "another_file.json": {},
-            "yet_another_file.json": {},
-            "first_match_me.json": {
+            {
+                "name": "another_file.json"
+            },
+            {
+                "name": "yet_another_file.json"
+            },
+            {
+                "name": "first_match_me.json",
                 "path": str(data_path / "match_me.json")
             },
-            "dont_match_me.json": {}
-        }
+            {
+                "name": "dont_match_me.json"
+            },
+        ]
     )
 
 
@@ -169,25 +184,33 @@ def test_basic_py_source_provider(config, context):
         source_provider=PySourceProvider({
             "fixed_name_file": Source(
                 storage=LocalFile(
-                    name="fixed_name_file.json"
+                    filters={
+                        "name": "fixed_name_file.json"
+                    }
                 ),
                 format=Json()
             ),
             "fixed_xml_file": Source(
                 storage=LocalFile(
-                    name="fixed_xml_file.xml"
+                    filters={
+                        "name": "fixed_xml_file.xml"
+                    }
                 ),
                 format=Xml()
             ),
             "name_match_file": Source(
                 storage=LocalFile(
-                    name_match=r".*match_me\.json"
+                    filters={
+                        "name": r".*match_me\.json"
+                    }
                 ),
                 format=Json()
             ),
             "name_match_file2": Source(
                 storage=LocalFile(
-                    name_match=re.compile(r".*match_me\.json")
+                    filters={
+                        "name": re.compile(r".*match_me\.json")
+                    }
                 ),
                 format=Json()
             )
@@ -207,9 +230,9 @@ def test_basic_py_source_provider(config, context):
 def test_basic_s3_file(s3_resource, config, context):
     s3_resource.create_bucket(Bucket="test")
     s3_resource.Object("test", "fixed_name_file.json").put(
-        Body=open(context.files["fixed_name_file.json"]["path"]).read()
+        Body=open(context.files[0]["path"]).read()
     )
-    context.files["fixed_name_file.json"]["s3uri"] = "s3://test/fixed_name_file.json"
+    context.files[0]["s3uri"] = "s3://test/fixed_name_file.json"
 
     config["sources"]["fixed_name_file"]["storage"]["class"] = "S3File"
 

--- a/tests/test_source_provider.py
+++ b/tests/test_source_provider.py
@@ -12,8 +12,8 @@ from mandible.metadata_mapper.storage import LocalFile
 @pytest.fixture
 def sources():
     return {
-        "json": Source(LocalFile(name="foo"), Json()),
-        "xml": Source(LocalFile(name="foo"), Xml())
+        "json": Source(LocalFile(filters={"name": "foo"}), Json()),
+        "xml": Source(LocalFile(filters={"name": "foo"}), Xml())
     }
 
 
@@ -28,7 +28,9 @@ def test_config_source_provider(sources):
         "json": {
             "storage": {
                 "class": "LocalFile",
-                "name": "foo"
+                "filters": {
+                    "name": "foo"
+                }
             },
             "format": {
                 "class": "Json"
@@ -37,7 +39,9 @@ def test_config_source_provider(sources):
         "xml": {
             "storage": {
                 "class": "LocalFile",
-                "name": "foo"
+                "filters": {
+                    "name": "foo"
+                }
             },
             "format": {
                 "class": "Xml"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,17 +4,22 @@ from hashlib import md5
 import pytest
 
 from mandible.metadata_mapper.context import Context
-from mandible.metadata_mapper.storage import LocalFile, S3File, Storage, StorageError
+from mandible.metadata_mapper.storage import (
+    STORAGE_REGISTRY,
+    LocalFile,
+    S3File,
+    StorageError,
+)
 
 
 def test_registry():
-    assert Storage.get_subclass("LocalFile") is LocalFile
-    assert Storage.get_subclass("S3File") is S3File
+    assert STORAGE_REGISTRY.get("LocalFile") is LocalFile
+    assert STORAGE_REGISTRY.get("S3File") is S3File
 
 
 def test_registry_error():
     with pytest.raises(KeyError):
-        Storage.get_subclass("FooBarBaz")
+        STORAGE_REGISTRY["FooBarBaz"]
 
 
 def test_local_file(data_path):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,9 +1,10 @@
 import io
+from hashlib import md5
 
 import pytest
 
 from mandible.metadata_mapper.context import Context
-from mandible.metadata_mapper.storage import LocalFile, S3File, Storage
+from mandible.metadata_mapper.storage import LocalFile, S3File, Storage, StorageError
 
 
 def test_registry():
@@ -18,13 +19,12 @@ def test_registry_error():
 
 def test_local_file(data_path):
     context = Context(
-        files={
-            "local_file": {
-                "path": str(data_path / "local_file.txt")
-            }
-        }
+        files=[{
+            "name": "local_file",
+            "path": str(data_path / "local_file.txt")
+        }]
     )
-    storage = LocalFile(name="local_file")
+    storage = LocalFile(filters={"name": "local_file"})
 
     with storage.open_file(context) as f:
         assert f.read() == b"Some local file content\n"
@@ -32,55 +32,97 @@ def test_local_file(data_path):
 
 def test_local_file_name_match(data_path):
     context = Context(
-        files={
-            "local_file": {
-                "path": str(data_path / "local_file.txt")
-            }
-        }
+        files=[{
+            "name": "local_file",
+            "path": str(data_path / "local_file.txt")
+        }]
     )
-    storage = LocalFile(name_match="local_.*")
+    storage = LocalFile(filters={"name": "local_.*"})
 
     with storage.open_file(context) as f:
         assert f.read() == b"Some local file content\n"
 
 
-def test_local_file_creation_error():
-    with pytest.raises(ValueError, match="You must provide"):
-        _ = LocalFile()
-    with pytest.raises(ValueError, match="You can't provide"):
-        _ = LocalFile(name="foo", name_match="foo")
+def test_local_file_int_filter(data_path):
+    context = Context(
+        files=[{
+            "type": 0,
+            "path": str(data_path / "local_file.txt")
+        }]
+    )
+    storage = LocalFile(filters={"type": 0})
+
+    with storage.open_file(context) as f:
+        assert f.read() == b"Some local file content\n"
 
 
-def test_local_file_name_error():
-    context = Context()
-    storage = LocalFile(name="foo.txt")
-
-    with pytest.raises(KeyError):
-        storage.open_file(context)
+def test_local_file_creation():
+    storage = LocalFile()
+    assert storage.filters == {}
 
 
 def test_local_file_name_match_error():
     context = Context()
-    storage = LocalFile(name_match="foo.*")
+    storage = LocalFile(filters={"name": "foo.*"})
 
-    with pytest.raises(RuntimeError, match="No files matched pattern"):
+    with pytest.raises(StorageError, match="No files matched filters"):
         storage.open_file(context)
 
 
-def test_s3_file(s3_resource):
+def test_s3_file_s3uri(s3_resource):
     bucket = s3_resource.Bucket("test-bucket")
     bucket.create()
     obj = bucket.Object("bucket_file.txt")
     obj.upload_fileobj(io.BytesIO(b"Some remote file content\n"))
 
     context = Context(
-        files={
-            "local_file": {
-                "s3uri": "s3://test-bucket/bucket_file.txt"
-            }
-        }
+        files=[{
+            "name": "s3_file",
+            "s3uri": "s3://test-bucket/bucket_file.txt"
+        }]
     )
-    storage = S3File(name="local_file")
+    storage = S3File(filters={"name": "s3_file"})
 
     with storage.open_file(context) as f:
         assert f.read() == b"Some remote file content\n"
+
+
+def test_s3_file_filters(s3_resource):
+    bucket = s3_resource.Bucket("test-bucket")
+    bucket.create()
+
+    def create_file(bucket, name, contents=None, type="data"):
+        contents = contents or f"Content from {name}\n".encode()
+        obj = bucket.Object(name)
+        obj.upload_fileobj(io.BytesIO(contents))
+
+        return {
+            "checksum": md5(contents).hexdigest(),
+            "checksumType": "md5",
+            "name": name,
+            "size": len(contents),
+            "type": type,
+            "uri": f"https://example.asf.alaska.edu/{name}",
+            "s3uri": f"s3://{bucket.name}/{name}",
+            "bucket": bucket.name,
+            "key": name
+        }
+
+    context = Context(
+        files=[
+            create_file(bucket, "file1.txt"),
+            create_file(bucket, "file2.txt", type="metadata"),
+        ]
+    )
+
+    storage = S3File(filters={
+        "name": "file1.txt"
+    })
+    with storage.open_file(context) as f:
+        assert f.read() == b"Content from file1.txt\n"
+
+    storage = S3File(filters={
+        "type": "metadata"
+    })
+    with storage.open_file(context) as f:
+        assert f.read() == b"Content from file2.txt\n"


### PR DESCRIPTION
This makes it possible to filter for sources based on more attributes than just the name. This will let us use some of those other fields sent in the CNM-S like `type` to filter by only `metadata` files, etc.

It is a breaking change to how the templates need to be written and how the `Context` object is constructed.