### PR TITLE
Improve error messages

### DIFF
--- a/mandible/metadata_mapper/__init__.py
+++ b/mandible/metadata_mapper/__init__.py
@@ -1,9 +1,12 @@
-from .mapper import Context, MetadataMapper, MetadataMapperError
+from .context import Context
+from .format import Format
+from .mapper import MetadataMapper, MetadataMapperError
 from .source import ConfigSourceProvider, PySourceProvider, Source
 
 __all__ = [
     "ConfigSourceProvider",
     "Context",
+    "Format",
     "MetadataMapper",
     "MetadataMapperError",
     "PySourceProvider",

--- a/mandible/metadata_mapper/__init__.py
+++ b/mandible/metadata_mapper/__init__.py
@@ -1,10 +1,11 @@
-from .mapper import Context, MetadataMapper
+from .mapper import Context, MetadataMapper, MetadataMapperError
 from .source import ConfigSourceProvider, PySourceProvider, Source
 
 __all__ = [
     "ConfigSourceProvider",
     "Context",
     "MetadataMapper",
+    "MetadataMapperError",
     "PySourceProvider",
-    "Source"
+    "Source",
 ]

--- a/mandible/metadata_mapper/format.py
+++ b/mandible/metadata_mapper/format.py
@@ -46,7 +46,7 @@ class Format(ABC):
         try:
             return self._eval_key(data, key)
         except KeyError as e:
-            raise FormatError(f"Key not found '{key}'") from e
+            raise FormatError(f"key not found '{key}'") from e
         except Exception as e:
             raise FormatError(f"'{key}' {e}") from e
 

--- a/mandible/metadata_mapper/mapper.py
+++ b/mandible/metadata_mapper/mapper.py
@@ -24,7 +24,7 @@ class MetadataMapper:
             try:
                 source.query_all_values(context)
             except Exception as e:
-                raise RuntimeError(f"Failed to query source '{name}'") from e
+                raise RuntimeError(f"failed to query source '{name}'") from e
 
         return self._replace_template(context, self.template, sources)
 

--- a/mandible/metadata_mapper/mapper.py
+++ b/mandible/metadata_mapper/mapper.py
@@ -7,6 +7,10 @@ from .source import Source, SourceProvider
 log = logging.getLogger(__name__)
 
 
+class MetadataMapperError(Exception):
+    pass
+
+
 class MetadataMapper:
     def __init__(self, template, source_provider: SourceProvider = None):
         self.template = template
@@ -24,7 +28,9 @@ class MetadataMapper:
             try:
                 source.query_all_values(context)
             except Exception as e:
-                raise RuntimeError(f"failed to query source '{name}'") from e
+                raise MetadataMapperError(
+                    f"failed to query source '{name}': {e}"
+                ) from e
 
         return self._replace_template(context, self.template, sources)
 

--- a/mandible/metadata_mapper/mapper.py
+++ b/mandible/metadata_mapper/mapper.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict
+from typing import Dict, Tuple
 
 from .context import Context
 from .source import Source, SourceProvider
@@ -21,7 +21,13 @@ class MetadataMapper:
             sources = self.source_provider.get_sources()
         else:
             sources = {}
-        self._cache_source_keys(context, sources)
+
+        try:
+            self._cache_source_keys(context, sources)
+        except Exception as e:
+            raise MetadataMapperError(
+                f"failed to process template: {e}"
+            )
 
         for name, source in sources.items():
             log.info("Querying source '%s': %s", name, source)
@@ -32,32 +38,26 @@ class MetadataMapper:
                     f"failed to query source '{name}': {e}"
                 ) from e
 
-        return self._replace_template(context, self.template, sources)
+        try:
+            return self._replace_template(context, self.template, sources)
+        except Exception as e:
+            raise MetadataMapperError(
+                f"failed to evaluate template: {e}"
+            ) from e
 
     def _cache_source_keys(self, context: Context, sources: Dict[str, Source]):
         for value in _walk_values(self.template):
             if isinstance(value, dict) and "@mapped" in value:
-                config = value["@mapped"]
-                source = config["source"]
-                key = config["key"]
-
-                if callable(key):
-                    key = key(context)
-
+                source, key = self._get_mapped_key(value, context)
                 sources[source].add_key(key)
 
     def _replace_template(self, context: Context, template, sources: Dict[str, Source]):
         if isinstance(template, dict):
             # TODO(reweeden): Implement functions as objects dynamically
             if "@mapped" in template:
-                config = template["@mapped"]
-                source = config["source"]
-                key = config["key"]
-
-                if callable(key):
-                    key = key(context)
-
+                source, key = self._get_mapped_key(template, context)
                 return sources[source].get_value(key)
+
             return {
                 k: self._replace_template(context, v, sources)
                 for k, v in template.items()
@@ -65,6 +65,21 @@ class MetadataMapper:
         if isinstance(template, list):
             return [self._replace_template(context, v, sources) for v in template]
         return template
+
+    def _get_mapped_key(self, value: dict, context: Context) -> Tuple[str, str]:
+        config = value["@mapped"]
+        source = config.get("source")
+        if source is None:
+            raise MetadataMapperError("@mapped attribute missing key 'source'")
+
+        key = config.get("key")
+        if key is None:
+            raise MetadataMapperError("@mapped attribute missing key 'key'")
+
+        if callable(key):
+            key = key(context)
+
+        return source, key
 
 
 def _walk_values(obj):

--- a/mandible/metadata_mapper/storage.py
+++ b/mandible/metadata_mapper/storage.py
@@ -40,7 +40,7 @@ class Storage(ABC):
             if self._matches_filters(info):
                 return info
 
-        raise StorageError(f"No files matched filters {self.filters}")
+        raise StorageError(f"no files matched filters {self.filters}")
 
     def _matches_filters(self, info: Dict[str, Any]) -> bool:
         for key, pattern in self._compiled_filters.items():

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -47,7 +47,7 @@ def test_h5_key_error():
 
     format = H5()
 
-    with pytest.raises(FormatError, match="Key not found 'foo'"):
+    with pytest.raises(FormatError, match="key not found 'foo'"):
         format.get_values(file, ["foo"])
 
 
@@ -79,7 +79,7 @@ def test_json_key_error():
     file = io.BytesIO(b"{}")
     format = Json()
 
-    with pytest.raises(FormatError, match="Key not found 'foo'"):
+    with pytest.raises(FormatError, match="key not found 'foo'"):
         format.get_values(file, ["foo"])
 
 
@@ -117,5 +117,5 @@ def test_xml_key_error():
 
     format = Xml()
 
-    with pytest.raises(FormatError, match="Key not found 'foo'"):
+    with pytest.raises(FormatError, match="key not found 'foo'"):
         format.get_values(file, ["foo"])

--- a/tests/test_metadata_mapper.py
+++ b/tests/test_metadata_mapper.py
@@ -290,3 +290,25 @@ def test_source_missing_key(config, context):
         )
     ):
         mapper.get_metadata(context)
+
+
+def test_mapped_missing_source(config, context):
+    mapper = MetadataMapper(
+        template={
+            "foo": {
+                "@mapped": {
+                    "key": "does not exist",
+                }
+            }
+        },
+        source_provider=ConfigSourceProvider(config["sources"])
+    )
+
+    with pytest.raises(
+        MetadataMapperError,
+        match=(
+            "failed to process template: "
+            "@mapped attribute missing key 'source'"
+        )
+    ):
+        mapper.get_metadata(context)

--- a/tests/test_metadata_mapper.py
+++ b/tests/test_metadata_mapper.py
@@ -6,6 +6,7 @@ from mandible.metadata_mapper import (
     ConfigSourceProvider,
     Context,
     MetadataMapper,
+    MetadataMapperError,
     PySourceProvider,
     Source,
 )
@@ -250,3 +251,42 @@ def test_basic_s3_file(s3_resource, config, context):
         "xml_foobar_1": "testing_1",
         "xml_foobar_2": "2",
     }
+
+
+def test_no_matching_files(config):
+    mapper = MetadataMapper(
+        template=config["template"],
+        source_provider=ConfigSourceProvider(config["sources"])
+    )
+
+    with pytest.raises(
+        MetadataMapperError,
+        match=(
+            "failed to query source 'fixed_name_file': "
+            "no files matched filters"
+        )
+    ):
+        mapper.get_metadata(Context())
+
+
+def test_source_missing_key(config, context):
+    mapper = MetadataMapper(
+        template={
+            "foo": {
+                "@mapped": {
+                    "source": "fixed_name_file",
+                    "key": "does not exist",
+                }
+            }
+        },
+        source_provider=ConfigSourceProvider(config["sources"])
+    )
+
+    with pytest.raises(
+        MetadataMapperError,
+        match=(
+            "failed to query source 'fixed_name_file': "
+            "key not found 'does not exist'"
+        )
+    ):
+        mapper.get_metadata(context)

--- a/tests/test_source_provider.py
+++ b/tests/test_source_provider.py
@@ -5,6 +5,7 @@ from mandible.metadata_mapper.source import (
     ConfigSourceProvider,
     PySourceProvider,
     Source,
+    SourceProviderError,
 )
 from mandible.metadata_mapper.storage import LocalFile
 
@@ -50,3 +51,127 @@ def test_config_source_provider(sources):
     })
 
     assert provider.get_sources() == sources
+
+
+def test_config_source_provider_empty():
+    provider = ConfigSourceProvider({})
+
+    assert provider.get_sources() == {}
+
+
+def test_config_source_provider_missing_storage():
+    provider = ConfigSourceProvider({
+        "source": {
+            "format": {
+                "class": "Json"
+            }
+        }
+    })
+
+    with pytest.raises(
+        SourceProviderError,
+        match="failed to create source 'source': missing key 'storage'"
+    ):
+        provider.get_sources()
+
+
+def test_config_source_provider_invalid_storage():
+    provider = ConfigSourceProvider({
+        "source": {
+            "storage": {
+                "class": "NotARealStorage"
+            }
+        }
+    })
+
+    with pytest.raises(
+        SourceProviderError,
+        match=(
+            "failed to create source 'source': "
+            "invalid storage type 'NotARealStorage'"
+        )
+    ):
+        provider.get_sources()
+
+
+def test_config_source_provider_invalid_storage_kwargs():
+    provider = ConfigSourceProvider({
+        "source": {
+            "storage": {
+                "class": "S3File",
+                "invalid_arg": 1
+            }
+        }
+    })
+
+    with pytest.raises(
+        SourceProviderError,
+        match=(
+            "failed to create source 'source': "
+            r"(Storage\.)?__init__\(\) got an unexpected keyword argument "
+            "'invalid_arg'"
+        )
+    ):
+        provider.get_sources()
+
+
+def test_config_source_provider_missing_format():
+    provider = ConfigSourceProvider({
+        "source": {
+            "storage": {
+                "class": "S3File"
+            }
+        }
+    })
+
+    with pytest.raises(
+        SourceProviderError,
+        match="failed to create source 'source': missing key 'format'"
+    ):
+        provider.get_sources()
+
+
+def test_config_source_provider_invalid_format():
+    provider = ConfigSourceProvider({
+        "source": {
+            "storage": {
+                "class": "S3File"
+            },
+            "format": {
+                "class": "NotARealFormat"
+            }
+        }
+    })
+
+    with pytest.raises(
+        SourceProviderError,
+        match=(
+            "failed to create source 'source': "
+            "invalid format type 'NotARealFormat'"
+        )
+    ):
+        provider.get_sources()
+
+
+def test_config_source_provider_invalid_format_kwargs():
+    provider = ConfigSourceProvider({
+        "source": {
+            "storage": {
+                "class": "S3File"
+            },
+            "format": {
+                "class": "Json",
+                "invalid_arg": 1
+            }
+        }
+    })
+
+    with pytest.raises(
+        SourceProviderError,
+        match=(
+            "failed to create source 'source': "
+            r"(Format\.)?__init__\(\) got an unexpected keyword argument "
+            "'invalid_arg'"
+        )
+    ):
+        provider.get_sources()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -70,7 +70,7 @@ def test_local_file_name_match_error():
     context = Context()
     storage = LocalFile(filters={"name": "foo.*"})
 
-    with pytest.raises(StorageError, match="No files matched filters"):
+    with pytest.raises(StorageError, match="no files matched filters"):
         storage.open_file(context)
 
 


### PR DESCRIPTION
Adds better error messages for when 
- the source config dictionary is set up wrong
- the `@mapped` attributes in the template are set up wrong
- the source cannot be queried

I made all the error messages start with a lowercase letter because I felt like that looked better, but we could also continue to go with uppercase instead.