### PR TITLE
Add test environment without package extras

### DIFF
--- a/mandible/metadata_mapper/format/__init__.py
+++ b/mandible/metadata_mapper/format/__init__.py
@@ -1,0 +1,21 @@
+from .format import FORMAT_REGISTRY, Format, FormatError, Json
+
+try:
+    from .h5 import H5
+except ImportError:
+    from .format import H5
+
+try:
+    from .xml import Xml
+except ImportError:
+    from .format import Xml
+
+
+__all__ = (
+    "FORMAT_REGISTRY",
+    "Format",
+    "FormatError",
+    "H5",
+    "Json",
+    "Xml",
+)

--- a/mandible/metadata_mapper/format/h5.py
+++ b/mandible/metadata_mapper/format/h5.py
@@ -1,0 +1,17 @@
+from typing import IO, Any, ContextManager
+
+import h5py
+
+from mandible.h5_parser import normalize
+
+from .format import Format
+
+
+class H5(Format):
+    @staticmethod
+    def _parse_data(file: IO[bytes]) -> ContextManager[Any]:
+        return h5py.File(file, "r")
+
+    @staticmethod
+    def _eval_key(data, key: str):
+        return normalize(data[key][()])

--- a/mandible/metadata_mapper/format/xml.py
+++ b/mandible/metadata_mapper/format/xml.py
@@ -1,0 +1,23 @@
+import contextlib
+from typing import IO, Any
+
+from lxml import etree
+
+from .format import Format
+
+
+class Xml(Format):
+    @staticmethod
+    @contextlib.contextmanager
+    def _parse_data(file: IO[bytes]) -> Any:
+        yield etree.parse(file)
+
+    @staticmethod
+    def _eval_key(data: etree.ElementTree, key: str):
+        elements = data.xpath(key)
+        if not elements:
+            raise KeyError(key)
+
+        # TODO(reweeden): Add a way to return the whole list here and not just
+        # the first element.
+        return elements[0].text

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,9 +1,13 @@
 import io
 
-import h5py
 import pytest
 
 from mandible.metadata_mapper.format import FORMAT_REGISTRY, H5, FormatError, Json, Xml
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
 
 
 def test_registry():
@@ -40,6 +44,7 @@ def test_h5():
     }
 
 
+@pytest.mark.h5
 def test_h5_key_error():
     file = io.BytesIO()
     with h5py.File(file, "w"):
@@ -112,6 +117,7 @@ def test_xml():
     }
 
 
+@pytest.mark.xml
 def test_xml_key_error():
     file = io.BytesIO(b"<root></root>")
 

--- a/tests/test_h5_parser.py
+++ b/tests/test_h5_parser.py
@@ -1,8 +1,14 @@
-import h5py
-import numpy as np
 import pytest
 
-from mandible.h5_parser import H5parser
+try:
+    import h5py
+    import numpy as np
+
+    from mandible.h5_parser import H5parser
+except ImportError:
+    pass
+
+pytestmark = pytest.mark.h5
 
 
 @pytest.fixture

--- a/tests/test_metadata_mapper.py
+++ b/tests/test_metadata_mapper.py
@@ -141,13 +141,37 @@ def test_constant_mapping_empty_context():
     assert mapper.get_metadata(Context()) == template
 
 
-def test_empty_context(mapper):
+def test_empty_context():
+    mapper = MetadataMapper(
+        template={
+            "foo": {
+                "@mapped": {
+                    "source": "fixed_name_file",
+                    "key": "foo"
+                }
+            }
+        },
+        source_provider=ConfigSourceProvider({
+            "fixed_name_file": {
+                "storage": {
+                    "class": "LocalFile",
+                    "filters": {
+                        "name": r"fixed_name_file\.json"
+                    }
+                },
+                "format": {
+                    "class": "Json",
+                }
+            }
+        })
+    )
     context = Context()
 
     with pytest.raises(Exception, match="fixed_name_file"):
         mapper.get_metadata(context)
 
 
+@pytest.mark.xml
 def test_basic(mapper, context):
     assert mapper.get_metadata(context) == {
         "foo": "value for foo",
@@ -160,6 +184,7 @@ def test_basic(mapper, context):
     }
 
 
+@pytest.mark.xml
 def test_mapped_key_callable(config, context):
     mapper = MetadataMapper(
         template={
@@ -179,6 +204,7 @@ def test_mapped_key_callable(config, context):
     }
 
 
+@pytest.mark.xml
 def test_basic_py_source_provider(config, context):
     mapper = MetadataMapper(
         template=config["template"],
@@ -228,6 +254,7 @@ def test_basic_py_source_provider(config, context):
     }
 
 
+@pytest.mark.xml
 def test_basic_s3_file(s3_resource, config, context):
     s3_resource.create_bucket(Bucket="test")
     s3_resource.Object("test", "fixed_name_file.json").put(
@@ -253,6 +280,7 @@ def test_basic_s3_file(s3_resource, config, context):
     }
 
 
+@pytest.mark.xml
 def test_no_matching_files(config):
     mapper = MetadataMapper(
         template=config["template"],
@@ -269,6 +297,7 @@ def test_no_matching_files(config):
         mapper.get_metadata(Context())
 
 
+@pytest.mark.xml
 def test_source_missing_key(config, context):
     mapper = MetadataMapper(
         template={
@@ -292,6 +321,7 @@ def test_source_missing_key(config, context):
         mapper.get_metadata(context)
 
 
+@pytest.mark.xml
 def test_mapped_missing_source(config, context):
     mapper = MetadataMapper(
         template={

--- a/tests/test_source_provider.py
+++ b/tests/test_source_provider.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mandible.metadata_mapper.format import Json, Xml
+from mandible.metadata_mapper.format import H5, Json, Xml
 from mandible.metadata_mapper.source import (
     ConfigSourceProvider,
     PySourceProvider,
@@ -13,8 +13,8 @@ from mandible.metadata_mapper.storage import LocalFile
 @pytest.fixture
 def sources():
     return {
-        "json": Source(LocalFile(filters={"name": "foo"}), Json()),
-        "xml": Source(LocalFile(filters={"name": "foo"}), Xml())
+        "foo": Source(LocalFile(filters={"name": "foo"}), Json()),
+        "bar": Source(LocalFile(filters={"name": "bar"}), Json())
     }
 
 
@@ -25,6 +25,37 @@ def test_py_source_provider(sources):
 
 
 def test_config_source_provider(sources):
+    provider = ConfigSourceProvider({
+        "foo": {
+            "storage": {
+                "class": "LocalFile",
+                "filters": {
+                    "name": "foo"
+                }
+            },
+            "format": {
+                "class": "Json"
+            }
+        },
+        "bar": {
+            "storage": {
+                "class": "LocalFile",
+                "filters": {
+                    "name": "bar"
+                }
+            },
+            "format": {
+                "class": "Json"
+            }
+        }
+    })
+
+    assert provider.get_sources() == sources
+
+
+@pytest.mark.h5
+@pytest.mark.xml
+def test_config_source_provider_all_formats():
     provider = ConfigSourceProvider({
         "json": {
             "storage": {
@@ -41,16 +72,31 @@ def test_config_source_provider(sources):
             "storage": {
                 "class": "LocalFile",
                 "filters": {
-                    "name": "foo"
+                    "name": "bar"
                 }
             },
             "format": {
                 "class": "Xml"
             }
+        },
+        "h5": {
+            "storage": {
+                "class": "LocalFile",
+                "filters": {
+                    "name": "baz"
+                }
+            },
+            "format": {
+                "class": "H5"
+            }
         }
     })
 
-    assert provider.get_sources() == sources
+    assert provider.get_sources() == {
+        "json": Source(LocalFile(filters={"name": "foo"}), Json()),
+        "xml": Source(LocalFile(filters={"name": "bar"}), Xml()),
+        "h5": Source(LocalFile(filters={"name": "baz"}), H5())
+    }
 
 
 def test_config_source_provider_empty():

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>4
 isolated_build = true
-env_list = py{38,39,310,311}
+env_list = py{38,39,310,311}-X{all,none}
 
 [gh-actions]
 python =
@@ -13,11 +13,14 @@ python =
 
 [testenv]
 allowlist_externals = poetry
-extras = all
 deps =
     boto3~=1.18
     moto~=4.0
     pytest~=7.1
     pytest-mock~=3.8.2
+extras =
+    Xnone:
+    Xall: all
 commands =
-    pytest tests/
+    Xnone: pytest tests/ -m "not h5 and not xml" {posargs}
+    Xall: pytest tests/ {posargs}


### PR DESCRIPTION
Add some tox test environments that will run the tests without having any extras installed. This should ensure that everything is still importable and minimally functional if the extras are not installed. Every test that requires an extra in order to run is marked with the appropriate pytest mark so it can be filtered out during test execution.

This also required some restructuring of the `metadata_mapper.format` module. I decided to try putting each of the formats that requires extra dependencies into it's own file so that the import errors could be easily caught in one place. The only downside of this was that I had to put the placeholders that raise a nice error message in the main format file which makes it a little harder to make sure that the names defined there are always matching with the names defined in the format files.

I ended up importing the placeholders if the real classes couldn't be imported, however another option could be to simply omit the classes from the `__all__` list if the import failed. This would make it so the app would fail at import time if a class is imported without the dependencies being installed but would also complicate the management of the `__all__` list in that `__init__` file.

Closes #7 