### PR TITLE
add namespace keyword arg to xpath

### DIFF
--- a/mandible/metadata_mapper/format/xml.py
+++ b/mandible/metadata_mapper/format/xml.py
@@ -14,7 +14,8 @@ class Xml(Format):
 
     @staticmethod
     def _eval_key(data: etree.ElementTree, key: str):
-        elements = data.xpath(key)
+        nsmap = data.getroot().nsmap
+        elements = data.xpath(key, namespaces=nsmap)
         if not elements:
             raise KeyError(key)
 

--- a/tests/data/xml_with_namespace.xml
+++ b/tests/data/xml_with_namespace.xml
@@ -1,0 +1,13 @@
+<root xmlns:foo="http:foobar/madeup/xml/namespace">
+  <foo:foo>
+    <foo:bar>
+      <foo:foobar>testing_1</foo:foobar>
+    </foo:bar>
+    <foo:bar>
+      <foo:foobar>2</foo:foobar>
+    </foo:bar>
+    <foo:bar>
+      <foo:foobar>testing_3</foo:foobar>
+    </foo:bar>
+  </foo:foo>
+</root>

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -118,6 +118,35 @@ def test_xml():
 
 
 @pytest.mark.xml
+def test_namespace_xml():
+    file = io.BytesIO(b"""
+    <root xmlns:foo="http://bigtest.com/namespace/docs">
+        <foo:foo>foo value</foo:foo>
+        <foo:bar>bar value</foo:bar>
+        <list>
+            <foo:v>list</foo:v>
+            <foo:v>value</foo:v>
+        </list>
+        <foo:nested>
+            <foo:qux>qux nested value</foo:qux>
+        </foo:nested>
+    </root>
+    """)
+    format = Xml()
+
+    # TODO(reweeden): Selecting lists is not supported
+    assert format.get_values(
+        file,
+        ["/root/foo:foo", "./foo:bar", "./list/foo:v[2]", "./foo:nested/foo:qux"]
+    ) == {
+        "/root/foo:foo": "foo value",
+        "./foo:bar": "bar value",
+        "./list/foo:v[2]": "value",
+        "./foo:nested/foo:qux": "qux nested value"
+    }
+
+
+@pytest.mark.xml
 def test_xml_key_error():
     file = io.BytesIO(b"<root></root>")
 

--- a/tests/test_metadata_mapper.py
+++ b/tests/test_metadata_mapper.py
@@ -51,6 +51,17 @@ def config():
                     "class": "Xml"
                 }
             },
+            "namespace_xml_file": {
+                "storage": {
+                    "class": "LocalFile",
+                    "filters": {
+                        "name": "xml_with_namespace.xml"
+                    }
+                },
+                "format": {
+                    "class": "Xml"
+                }
+            }
         },
         "template": {
             "foo": {
@@ -84,7 +95,19 @@ def config():
                     "source": "fixed_xml_file",
                     "key": "./foo/bar[2]/foobar"
                 }
-            }
+            },
+            "namespace_xml_foobar_1": {
+                "@mapped": {
+                    "source": "namespace_xml_file",
+                    "key": "./foo:foo/foo:bar[1]/foo:foobar"
+                }
+            },
+            "namespace_xml_foobar_2": {
+                "@mapped": {
+                    "source": "namespace_xml_file",
+                    "key": "./foo:foo/foo:bar[2]/foo:foobar"
+                }
+            },
         }
     }
 
@@ -100,6 +123,10 @@ def context(data_path):
             {
                 "name": "fixed_xml_file.xml",
                 "path": str(data_path / "fixed_xml_file.xml")
+            },
+            {
+                "name": "xml_with_namespace.xml",
+                "path": str(data_path / "xml_with_namespace.xml")
             },
             {
                 "name": "another_file.json"
@@ -179,6 +206,8 @@ def test_basic(mapper, context):
             "nested": "value for nested",
             "bar": "value for bar"
         },
+        "namespace_xml_foobar_1": "testing_1",
+        "namespace_xml_foobar_2": "2",
         "xml_foobar_1": "testing_1",
         "xml_foobar_2": "2",
     }
@@ -225,6 +254,14 @@ def test_basic_py_source_provider(config, context):
                 ),
                 format=Xml()
             ),
+            "namespace_xml_file": Source(
+                storage=LocalFile(
+                    filters={
+                        "name": "xml_with_namespace.xml"
+                    }
+                ),
+                format=Xml()
+            ),
             "name_match_file": Source(
                 storage=LocalFile(
                     filters={
@@ -249,6 +286,8 @@ def test_basic_py_source_provider(config, context):
             "nested": "value for nested",
             "bar": "value for bar"
         },
+        "namespace_xml_foobar_1": "testing_1",
+        "namespace_xml_foobar_2": "2",
         "xml_foobar_1": "testing_1",
         "xml_foobar_2": "2",
     }
@@ -275,6 +314,8 @@ def test_basic_s3_file(s3_resource, config, context):
             "nested": "value for nested",
             "bar": "value for bar"
         },
+        "namespace_xml_foobar_1": "testing_1",
+        "namespace_xml_foobar_2": "2",
         "xml_foobar_1": "testing_1",
         "xml_foobar_2": "2",
     }


### PR DESCRIPTION
If there is no namespace defined it returns {} and if there is, then it enables namespace based reading, required for the iso.xml that is using the xml namespaces for the files to be read by GIS software. 