### PR TITLE
Refactor directives and template errors

### DIFF
--- a/mandible/metadata_mapper/mapper.py
+++ b/mandible/metadata_mapper/mapper.py
@@ -81,10 +81,16 @@ class Mapped(TemplateDirective):
 
 
 class MetadataMapper:
-    def __init__(self, template, source_provider: SourceProvider = None):
+    def __init__(
+        self,
+        template,
+        source_provider: SourceProvider = None,
+        *,
+        directive_marker: str = "@"
+    ):
         self.template = template
         self.source_provider = source_provider
-        self.directive_marker = "@"
+        self.directive_marker = directive_marker
         self.directives = {
             "mapped": Mapped
         }

--- a/mandible/metadata_mapper/storage.py
+++ b/mandible/metadata_mapper/storage.py
@@ -36,6 +36,11 @@ class Storage(ABC):
 
     def get_file_from_context(self, context: Context) -> Dict[str, Any]:
         """Return the file from the context which matches all filters."""
+
+        # Special error message to make debugging empty context easier
+        if not context.files:
+            raise StorageError("no files in context")
+
         for info in context.files:
             if self._matches_filters(info):
                 return info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.2.0"
+version = "0.2.1"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"

--- a/tests/test_metadata_mapper.py
+++ b/tests/test_metadata_mapper.py
@@ -234,6 +234,26 @@ def test_mapped_key_callable(config, context):
     }
 
 
+def test_custom_directive(context, fixed_name_file_config):
+    mapper = MetadataMapper(
+        template={
+            "foo": {
+                "#mapped": {
+                    "source": "fixed_name_file",
+                    "key": "foo"
+                }
+            },
+        },
+        source_provider=ConfigSourceProvider({
+            "fixed_name_file": fixed_name_file_config
+        }),
+        directive_marker="#"
+    )
+    assert mapper.get_metadata(context) == {
+        "foo": "value for foo"
+    }
+
+
 @pytest.mark.xml
 def test_basic_py_source_provider(config, context):
     mapper = MetadataMapper(

--- a/tests/test_metadata_mapper.py
+++ b/tests/test_metadata_mapper.py
@@ -193,7 +193,7 @@ def test_empty_context(fixed_name_file_config):
         MetadataMapperError,
         match=(
             "failed to query source 'fixed_name_file': "
-            "no files matched filters"
+            "no files in context"
         )
     ):
         mapper.get_metadata(context)
@@ -342,22 +342,39 @@ def test_basic_s3_file(s3_resource, config, context):
     }
 
 
-# TODO(reweeden): There is already a test_empty_context which checks this
-@pytest.mark.xml
-def test_no_matching_files(config):
+def test_no_matching_files(context):
     mapper = MetadataMapper(
-        template=config["template"],
-        source_provider=ConfigSourceProvider(config["sources"])
+        template={
+            "foo": {
+                "@mapped": {
+                    "source": "source_file",
+                    "key": "foo"
+                }
+            }
+        },
+        source_provider=ConfigSourceProvider({
+            "source_file": {
+                "storage": {
+                    "class": "LocalFile",
+                    "filters": {
+                        "name": "does not exist"
+                    }
+                },
+                "format": {
+                    "class": "Json"
+                }
+            }
+        })
     )
 
     with pytest.raises(
         MetadataMapperError,
         match=(
-            "failed to query source 'fixed_name_file': "
+            "failed to query source 'source_file': "
             "no files matched filters"
         )
     ):
-        mapper.get_metadata(Context())
+        mapper.get_metadata(context)
 
 
 def test_source_non_existent_key(context, fixed_name_file_config):

--- a/tests/test_metadata_mapper.py
+++ b/tests/test_metadata_mapper.py
@@ -362,8 +362,7 @@ def test_source_missing_key(config, context):
         mapper.get_metadata(context)
 
 
-@pytest.mark.xml
-def test_mapped_missing_source(config, context):
+def test_mapped_missing_source(context):
     mapper = MetadataMapper(
         template={
             "foo": {
@@ -372,13 +371,41 @@ def test_mapped_missing_source(config, context):
                 }
             }
         },
-        source_provider=ConfigSourceProvider(config["sources"])
+        source_provider=ConfigSourceProvider({})
     )
 
     with pytest.raises(
         MetadataMapperError,
         match=(
-            "failed to process template: "
+            r"failed to process template at \$\.foo: "
+            "@mapped attribute missing key 'source'"
+        )
+    ):
+        mapper.get_metadata(context)
+
+
+def test_mapped_missing_source_path(context):
+    mapper = MetadataMapper(
+        template={
+            "foo": {
+                "bar": [
+                    "ignored",
+                    "ignored",
+                    {
+                        "@mapped": {
+                            "key": "does not exist",
+                        }
+                    }
+                ]
+            }
+        },
+        source_provider=ConfigSourceProvider({})
+    )
+
+    with pytest.raises(
+        MetadataMapperError,
+        match=(
+            r"failed to process template at \$\.foo\.bar\[2\]: "
             "@mapped attribute missing key 'source'"
         )
     ):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -67,10 +67,20 @@ def test_local_file_creation():
 
 
 def test_local_file_name_match_error():
-    context = Context()
+    context = Context(
+        files=[{"name": "local_file"}]
+    )
     storage = LocalFile(filters={"name": "foo.*"})
 
     with pytest.raises(StorageError, match="no files matched filters"):
+        storage.open_file(context)
+
+
+def test_local_file_empty_context_error():
+    context = Context()
+    storage = LocalFile(filters={"name": "foo.*"})
+
+    with pytest.raises(StorageError, match="no files in context"):
         storage.open_file(context)
 
 


### PR DESCRIPTION
This moves the logic for handling the `@mapped` parts of the template into its own class and sets up an abstraction called a `Directive` which would allow for other functionality to be added easily in the future.

I also had the opportunity to improve template parsing errors a little more so they now include the path to the object which caused the error.