### PR TITLE
Fix booleans not being returned from the h5 parser

### DIFF
--- a/mandible/h5_parser.py
+++ b/mandible/h5_parser.py
@@ -26,10 +26,6 @@ class H5parser(dict):
 
 
 def normalize(node_val):
-    if isinstance(node_val, np.integer):
-        return int(node_val)
-    if isinstance(node_val, np.floating):
-        return float(node_val)
     if isinstance(node_val, np.ndarray):
         value = node_val.tolist()
         if isinstance(value[0], bytes):
@@ -37,3 +33,5 @@ def normalize(node_val):
         return value
     if isinstance(node_val, bytes):
         return node_val.decode("utf-8")
+
+    return node_val

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.3.0"
+version = "0.3.1"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"


### PR DESCRIPTION
There was no fall through case when no conversions needed to happen, so booleans were being turned into `None` mistakenly. I removed the conversion cases for integers and floats as they seem to be redundant.