### PR TITLE
Fix h5 type returns

### DIFF
--- a/mandible/h5_parser.py
+++ b/mandible/h5_parser.py
@@ -26,6 +26,12 @@ class H5parser(dict):
 
 
 def normalize(node_val):
+    if isinstance(node_val, np.bool_):
+        return bool(node_val)
+    if isinstance(node_val, np.integer):
+        return int(node_val)
+    if isinstance(node_val, np.floating):
+        return float(node_val)
     if isinstance(node_val, np.ndarray):
         value = node_val.tolist()
         if isinstance(value[0], bytes):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.3.1"
+version = "0.3.2"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"

--- a/tests/test_h5_parser.py
+++ b/tests/test_h5_parser.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 try:
@@ -78,3 +80,5 @@ def test_h5_parser_types(h5_test_file):
     data.read_file(h5_test_file)
 
     assert data == expected
+    # Check that types are JSON serializable
+    assert json.loads(json.dumps(data)) == expected


### PR DESCRIPTION
Got tricked by equality comparison I think... The types were comparing equal but they were actually being returned as special numpy objects. We add a serialization step to the tests to catch this.