### PR TITLE
Add directive for re-parsing extracted values

### DIFF
--- a/mandible/jsonpath.py
+++ b/mandible/jsonpath.py
@@ -1,0 +1,23 @@
+try:
+    import jsonpath_ng
+    import jsonpath_ng.ext
+except ImportError:
+    jsonpath_ng = None
+
+
+def get_key(data: dict, key: str):
+    # Fall back to simple dot paths
+    if jsonpath_ng is None:
+        val = data
+        for key in key.split("."):
+            val = val[key]
+
+        return val
+
+    expr = jsonpath_ng.ext.parse(key)
+    # TODO(reweeden): Add a way to return the whole list here and not just
+    # the first element.
+    try:
+        return next(match.value for match in expr.find(data))
+    except StopIteration:
+        raise KeyError(key)

--- a/mandible/jsonpath.py
+++ b/mandible/jsonpath.py
@@ -8,6 +8,9 @@ except ImportError:
 def get_key(data: dict, key: str):
     # Fall back to simple dot paths
     if jsonpath_ng is None:
+        if key == "$":
+            return data
+
         val = data
         for key in key.split("."):
             val = val[key]

--- a/mandible/metadata_mapper/directive.py
+++ b/mandible/metadata_mapper/directive.py
@@ -1,0 +1,57 @@
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, Union
+
+from .context import Context
+from .exception import MetadataMapperError
+from .source import Source
+
+
+class TemplateDirective(ABC):
+    """Base class for directives in a metadata template.
+
+    A directive is a special marker in the metadata template which will be
+    replaced by the MetadataMapper.
+    """
+
+    def __init__(self, context: Context, sources: Dict[str, Source]):
+        self.context = context
+        self.sources = sources
+
+    @abstractmethod
+    def call(self):
+        pass
+
+    def prepare(self):
+        pass
+
+
+class Mapped(TemplateDirective):
+    """A value mapped to the template from a metadata Source.
+
+    The directive will be replaced by looking at the specified Source and
+    extracting the defined key.
+    """
+    def __init__(
+        self,
+        context: Context,
+        sources: Dict[str, Source],
+        source: str,
+        key: Union[str, Callable[[Context], str]]
+    ):
+        super().__init__(context, sources)
+
+        if source not in sources:
+            raise MetadataMapperError(f"source '{source}' does not exist")
+
+        self.source = sources[source]
+        if callable(key):
+            key = key(context)
+        self.key = key
+
+    def call(self):
+        return self.source.get_value(self.key)
+
+    def prepare(self):
+        self.source.add_key(self.key)
+
+

--- a/mandible/metadata_mapper/directive.py
+++ b/mandible/metadata_mapper/directive.py
@@ -1,9 +1,20 @@
+import io
 from abc import ABC, abstractmethod
-from typing import Callable, Dict, Union
+from typing import Any, Callable, Dict, Union
 
 from .context import Context
 from .exception import MetadataMapperError
+from .format import FORMAT_REGISTRY
 from .source import Source
+
+Key = Union[str, Callable[[Context], str]]
+
+
+def get_key(key: Key, context: Context) -> str:
+    if callable(key):
+        key = key(context)
+
+    return key
 
 
 class TemplateDirective(ABC):
@@ -36,7 +47,7 @@ class Mapped(TemplateDirective):
         context: Context,
         sources: Dict[str, Source],
         source: str,
-        key: Union[str, Callable[[Context], str]]
+        key: Key
     ):
         super().__init__(context, sources)
 
@@ -44,9 +55,7 @@ class Mapped(TemplateDirective):
             raise MetadataMapperError(f"source '{source}' does not exist")
 
         self.source = sources[source]
-        if callable(key):
-            key = key(context)
-        self.key = key
+        self.key = get_key(key, context)
 
     def call(self):
         return self.source.get_value(self.key)
@@ -55,3 +64,42 @@ class Mapped(TemplateDirective):
         self.source.add_key(self.key)
 
 
+class Reformatted(TemplateDirective):
+    """A value mapped to the template from a metadata Source.
+
+    The directive will be replaced by looking at the specified Source and
+    extracting the defined key.
+    """
+    def __init__(
+        self,
+        context: Context,
+        sources: Dict[str, Source],
+        format: str,
+        value: Any,
+        key: Key
+    ):
+        super().__init__(context, sources)
+
+        format_cls = FORMAT_REGISTRY.get(format)
+        if format_cls is None:
+            raise MetadataMapperError(f"format '{format}' does not exist")
+
+        self.format = format_cls()
+        self.value = value
+        self.key = get_key(key, context)
+
+    def call(self):
+        if isinstance(self.value, bytes):
+            value = self.value
+        elif isinstance(self.value, str):
+            value = self.value.encode()
+        else:
+            raise MetadataMapperError(
+                "value must be of type 'bytes' or 'str' but got "
+                f"'{type(self.value).__name__}'"
+            )
+
+        return self.format.get_value(
+            io.BytesIO(value),
+            self.key
+        )

--- a/mandible/metadata_mapper/exception.py
+++ b/mandible/metadata_mapper/exception.py
@@ -1,0 +1,20 @@
+class MetadataMapperError(Exception):
+    """A generic error raised by the MetadataMapper"""
+
+    def __init__(self, msg: str):
+        self.msg = msg
+
+
+class TemplateError(MetadataMapperError):
+    """An error that occurred while processing the metadata template."""
+
+    def __init__(self, msg: str, debug_path: str = None):
+        super().__init__(msg)
+        self.debug_path = debug_path
+
+    def __str__(self) -> str:
+        debug = ""
+        if self.debug_path is not None:
+            debug = f" at {self.debug_path}"
+
+        return f"failed to process template{debug}: {self.msg}"

--- a/mandible/metadata_mapper/format/format.py
+++ b/mandible/metadata_mapper/format/format.py
@@ -19,10 +19,9 @@ FORMAT_REGISTRY: Dict[str, Type["Format"]] = {}
 @dataclass
 class Format(ABC):
     # Registry boilerplate
-    def __init_subclass__(cls):
-        name = cls.__name__
-        if not name.startswith("_"):
-            FORMAT_REGISTRY[name] = cls
+    def __init_subclass__(cls, register: bool = True):
+        if register:
+            FORMAT_REGISTRY[cls.__name__] = cls
 
     # Begin class definition
     def get_values(self, file: IO[bytes], keys: Iterable[str]):
@@ -53,7 +52,7 @@ class Format(ABC):
 
 # Define placeholders for when extras are not installed
 
-class _PlaceholderBase(Format):
+class _PlaceholderBase(Format, register=False):
     """
     Base class for defining placeholder implementations for classes that
     require extra dependencies to be installed

--- a/mandible/metadata_mapper/format/format.py
+++ b/mandible/metadata_mapper/format/format.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import IO, Any, ContextManager, Dict, Iterable, Type
 
+from mandible import jsonpath
+
 
 class FormatError(Exception):
     def __init__(self, reason: str):
@@ -30,6 +32,12 @@ class Format(ABC):
                 key: self._eval_key_wrapper(data, key)
                 for key in keys
             }
+
+    def get_value(self, file: IO[bytes], key: str):
+        """Convenience function for getting a single value"""
+
+        with self._parse_data(file) as data:
+            return self._eval_key_wrapper(data, key)
 
     def _eval_key_wrapper(self, data, key: str):
         try:
@@ -92,8 +100,4 @@ class Json(Format):
 
     @staticmethod
     def _eval_key(data: dict, key: str):
-        val = data
-        for key in key.split("."):
-            val = val[key]
-
-        return val
+        return jsonpath.get_key(data, key)

--- a/mandible/metadata_mapper/mapper.py
+++ b/mandible/metadata_mapper/mapper.py
@@ -1,62 +1,13 @@
 import inspect
 import logging
-from abc import ABC, abstractmethod
-from typing import Callable, Dict, Optional, Union
+from typing import Dict, Optional
 
 from .context import Context
+from .directive import Mapped, TemplateDirective
 from .exception import MetadataMapperError, TemplateError
 from .source import Source, SourceProvider
 
 log = logging.getLogger(__name__)
-
-
-class TemplateDirective(ABC):
-    """Base class for directives in a metadata template.
-
-    A directive is a special marker in the metadata template which will be
-    replaced by the MetadataMapper.
-    """
-
-    def __init__(self, context: Context, sources: Dict[str, Source]):
-        self.context = context
-        self.sources = sources
-
-    @abstractmethod
-    def call(self):
-        pass
-
-    def prepare(self):
-        pass
-
-
-class Mapped(TemplateDirective):
-    """A value mapped to the template from a metadata Source.
-
-    The directive will be replaced by looking at the specified Source and
-    extracting the defined key.
-    """
-    def __init__(
-        self,
-        context: Context,
-        sources: Dict[str, Source],
-        source: str,
-        key: Union[str, Callable[[Context], str]]
-    ):
-        super().__init__(context, sources)
-
-        if source not in sources:
-            raise MetadataMapperError(f"source '{source}' does not exist")
-
-        self.source = sources[source]
-        if callable(key):
-            key = key(context)
-        self.key = key
-
-    def call(self):
-        return self.source.get_value(self.key)
-
-    def prepare(self):
-        self.source.add_key(self.key)
 
 
 class MetadataMapper:

--- a/mandible/metadata_mapper/mapper.py
+++ b/mandible/metadata_mapper/mapper.py
@@ -4,31 +4,10 @@ from abc import ABC, abstractmethod
 from typing import Callable, Dict, Optional, Union
 
 from .context import Context
+from .exception import MetadataMapperError, TemplateError
 from .source import Source, SourceProvider
 
 log = logging.getLogger(__name__)
-
-
-class MetadataMapperError(Exception):
-    """A generic error raised by the MetadataMapper"""
-
-    def __init__(self, msg: str):
-        self.msg = msg
-
-
-class TemplateError(MetadataMapperError):
-    """An error that occurred while processing the metadata template."""
-
-    def __init__(self, msg: str, debug_path: str = None):
-        super().__init__(msg)
-        self.debug_path = debug_path
-
-    def __str__(self) -> str:
-        debug = ""
-        if self.debug_path is not None:
-            debug = f" at {self.debug_path}"
-
-        return f"failed to process template{debug}: {self.msg}"
 
 
 class TemplateDirective(ABC):

--- a/mandible/metadata_mapper/mapper.py
+++ b/mandible/metadata_mapper/mapper.py
@@ -3,7 +3,7 @@ import logging
 from typing import Dict, Optional
 
 from .context import Context
-from .directive import Mapped, TemplateDirective
+from .directive import Mapped, Reformatted, TemplateDirective
 from .exception import MetadataMapperError, TemplateError
 from .source import Source, SourceProvider
 
@@ -22,7 +22,8 @@ class MetadataMapper:
         self.source_provider = source_provider
         self.directive_marker = directive_marker
         self.directives = {
-            "mapped": Mapped
+            "mapped": Mapped,
+            "reformatted": Reformatted,
         }
 
     def get_metadata(self, context: Context) -> Dict:

--- a/mandible/metadata_mapper/storage.py
+++ b/mandible/metadata_mapper/storage.py
@@ -1,7 +1,8 @@
+import io
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import IO, Any, Dict, Type
+from typing import IO, Any, Dict, Type, Union
 
 import s3fs
 
@@ -15,13 +16,41 @@ class StorageError(Exception):
 STORAGE_REGISTRY: Dict[str, Type["Storage"]] = {}
 
 
-@dataclass
 class Storage(ABC):
     # Registry boilerplate
     def __init_subclass__(cls, register: bool = True):
         if register:
             STORAGE_REGISTRY[cls.__name__] = cls
 
+    @abstractmethod
+    def open_file(self, context: Context) -> IO[bytes]:
+        """Get a filelike object to access the data."""
+        pass
+
+
+@dataclass
+class Dummy(Storage):
+    """A dummy storage that returns a hardcoded byte stream.
+
+    Used for testing.
+    """
+
+    data: Union[str, bytes]
+
+    def open_file(self, context: Context) -> IO[bytes]:
+        if isinstance(self.data, str):
+            data = self.data.encode()
+        else:
+            data = self.data
+
+        return io.BytesIO(data)
+
+
+@dataclass
+class FilteredStorage(Storage, register=False):
+    """A storage which matches a set of filters on the context's files and
+    returns data from the matching file.
+    """
     # Begin class definition
     filters: Dict[str, str] = field(default_factory=dict)
 
@@ -67,12 +96,14 @@ class Storage(ABC):
         pass
 
 
-class LocalFile(Storage):
+@dataclass
+class LocalFile(FilteredStorage):
     def _open_file(self, info: Dict) -> IO[bytes]:
         return open(info["path"], "rb")
 
 
-class S3File(Storage):
+@dataclass
+class S3File(FilteredStorage):
     def _open_file(self, info: Dict) -> IO[bytes]:
         s3 = s3fs.S3FileSystem(anon=False)
         return s3.open(f"s3://{info['bucket']}/{info['key']}")

--- a/mandible/metadata_mapper/storage.py
+++ b/mandible/metadata_mapper/storage.py
@@ -18,8 +18,9 @@ STORAGE_REGISTRY: Dict[str, Type["Storage"]] = {}
 @dataclass
 class Storage(ABC):
     # Registry boilerplate
-    def __init_subclass__(cls):
-        STORAGE_REGISTRY[cls.__name__] = cls
+    def __init_subclass__(cls, register: bool = True):
+        if register:
+            STORAGE_REGISTRY[cls.__name__] = cls
 
     # Begin class definition
     filters: Dict[str, str] = field(default_factory=dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,14 @@ s3fs = "^0.4.2"
 
 # Optional
 h5py = { version = "^3.6.0", optional = true }
+jsonpath-ng = { version = "^1.5.3", optional = true }
 lxml = { version = "^4.9.2", optional = true }
 numpy = { version = "^1.21.6", optional = true }
 
 [tool.poetry.extras]
-all = ["h5py", "numpy", "lxml"]
+all = ["h5py", "numpy", "jsonpath-ng", "lxml"]
 h5 = ["h5py", "numpy"]
+jsonpath = ["jsonpath-ng"]
 xml = ["lxml"]
 
 
@@ -39,6 +41,7 @@ pytest-mock = "^3.8.2"
 [tool.pytest.ini_options]
 markers = [
     "h5: requires the 'h5' extra to be installed",
+    "jsonpath: requires the 'jsonpath' extra to be installed",
     "xml: requires the 'xml' extra to be installed",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ s3fs = "^0.4.2"
 
 # Optional
 h5py = { version = "^3.6.0", optional = true }
-jsonpath-ng = { version = "^1.5.3", optional = true }
+jsonpath-ng = { version = "^1.4.0", optional = true }
 lxml = { version = "^4.9.2", optional = true }
 numpy = { version = "^1.21.6", optional = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "APACHE-2"
 readme = "README.md"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.3.2"
+version = "0.4.0"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -2,7 +2,14 @@ import io
 
 import pytest
 
-from mandible.metadata_mapper.format import FORMAT_REGISTRY, H5, FormatError, Json, Xml
+from mandible.metadata_mapper.format import (
+    FORMAT_REGISTRY,
+    H5,
+    Format,
+    FormatError,
+    Json,
+    Xml,
+)
 
 try:
     import h5py
@@ -11,9 +18,18 @@ except ImportError:
 
 
 def test_registry():
-    assert FORMAT_REGISTRY.get("H5") is H5
-    assert FORMAT_REGISTRY.get("Json") is Json
-    assert FORMAT_REGISTRY.get("Xml") is Xml
+    assert FORMAT_REGISTRY == {
+        "H5": H5,
+        "Json": Json,
+        "Xml": Xml,
+    }
+
+
+def test_registry_intermediate_class():
+    class Foo(Format, register=False):
+        pass
+
+    assert "Foo" not in FORMAT_REGISTRY
 
 
 def test_registry_error():

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -61,6 +61,19 @@ def test_h5():
 
 
 @pytest.mark.h5
+def test_h5_empty_key():
+    file = io.BytesIO()
+    with h5py.File(file, "w") as f:
+        f["foo"] = "foo value"
+        f["bar"] = "bar value"
+
+    format = H5()
+
+    with pytest.raises(FormatError, match="cannot be an empty string"):
+        format.get_value(file, "")
+
+
+@pytest.mark.h5
 def test_h5_key_error():
     file = io.BytesIO()
     with h5py.File(file, "w"):
@@ -93,6 +106,21 @@ def test_json():
         "bar": "bar value",
         "list": ["list", "value"],
         "nested.qux": "qux nested value"
+    }
+
+
+def test_json_dollar_key():
+    file = io.BytesIO(b"""
+    {
+        "foo": "foo value",
+        "bar": "bar value"
+    }
+    """)
+    format = Json()
+
+    assert format.get_value(file, "$") == {
+        "foo": "foo value",
+        "bar": "bar value",
     }
 
 
@@ -131,6 +159,19 @@ def test_xml():
         "./list/v[2]": "value",
         "./nested/qux": "qux nested value"
     }
+
+
+@pytest.mark.xml
+def test_xml_empty_key():
+    file = io.BytesIO(b"""
+    <root>
+        <foo>foo value</foo>
+        <bar>bar value</bar>
+    </root>
+    """)
+    format = Xml()
+
+    assert format.get_values(file, "") == {}
 
 
 @pytest.mark.xml

--- a/tests/test_metadata_mapper.py
+++ b/tests/test_metadata_mapper.py
@@ -419,7 +419,7 @@ def test_mapped_non_existent_source(context):
     with pytest.raises(
         MetadataMapperError,
         match=(
-            r"failed to process template at \$\.foo: "
+            r"failed to process template at \$\.foo\.@mapped: "
             "source 'does not exist' does not exist"
         )
     ):
@@ -441,8 +441,8 @@ def test_mapped_missing_key(context):
     with pytest.raises(
         MetadataMapperError,
         match=(
-            r"failed to process template at \$\.foo: "
-            "@mapped directive missing key: 'key'"
+            r"failed to process template at \$\.foo\.@mapped: "
+            "missing key: 'key'"
         )
     ):
         mapper.get_metadata(context)
@@ -463,8 +463,8 @@ def test_mapped_missing_source(context):
     with pytest.raises(
         MetadataMapperError,
         match=(
-            r"failed to process template at \$\.foo: "
-            "@mapped directive missing key: 'source'"
+            r"failed to process template at \$\.foo\.@mapped: "
+            "missing key: 'source'"
         )
     ):
         mapper.get_metadata(context)
@@ -491,8 +491,8 @@ def test_mapped_missing_source_path(context):
     with pytest.raises(
         MetadataMapperError,
         match=(
-            r"failed to process template at \$\.foo\.bar\[2\]: "
-            "@mapped directive missing key: 'source'"
+            r"failed to process template at \$\.foo\.bar\[2\]\.@mapped: "
+            "missing key: 'source'"
         )
     ):
         mapper.get_metadata(context)
@@ -511,8 +511,8 @@ def test_mapped_missing_source_and_key(context):
     with pytest.raises(
         MetadataMapperError,
         match=(
-            r"failed to process template at \$\.foo: "
-            "@mapped directive missing keys: 'key', 'source'"
+            r"failed to process template at \$\.foo\.@mapped: "
+            "missing keys: 'key', 'source'"
         )
     ):
         mapper.get_metadata(context)
@@ -551,7 +551,7 @@ def test_invalid_directive(context):
     with pytest.raises(
         MetadataMapperError,
         match=(
-            r"failed to process template at \$\.foo: "
+            r"failed to process template at \$\.foo\.@does_not_exist: "
             "invalid directive '@does_not_exist'"
         )
     ):

--- a/tests/test_metadata_mapper.py
+++ b/tests/test_metadata_mapper.py
@@ -384,7 +384,7 @@ def test_source_non_existent_key(context, fixed_name_file_config):
             "foo": {
                 "@mapped": {
                     "source": "fixed_name_file",
-                    "key": "does not exist",
+                    "key": "does_not_exist",
                 }
             }
         },
@@ -397,8 +397,8 @@ def test_source_non_existent_key(context, fixed_name_file_config):
         MetadataMapperError,
         match=(
             "failed to query source 'fixed_name_file': "
-            "key not found 'does not exist'"
-        )
+            "key not found 'does_not_exist'"
+        ),
     ):
         mapper.get_metadata(context)
 

--- a/tests/test_source_provider.py
+++ b/tests/test_source_provider.py
@@ -7,7 +7,7 @@ from mandible.metadata_mapper.source import (
     Source,
     SourceProviderError,
 )
-from mandible.metadata_mapper.storage import LocalFile
+from mandible.metadata_mapper.storage import STORAGE_REGISTRY, LocalFile
 
 
 @pytest.fixture
@@ -140,11 +140,12 @@ def test_config_source_provider_invalid_storage():
         provider.get_sources()
 
 
-def test_config_source_provider_invalid_storage_kwargs():
+@pytest.mark.parametrize("cls_name", STORAGE_REGISTRY.keys())
+def test_config_source_provider_invalid_storage_kwargs(cls_name):
     provider = ConfigSourceProvider({
         "source": {
             "storage": {
-                "class": "S3File",
+                "class": cls_name,
                 "invalid_arg": 1
             }
         }
@@ -154,7 +155,7 @@ def test_config_source_provider_invalid_storage_kwargs():
         SourceProviderError,
         match=(
             "failed to create source 'source': "
-            r"(Storage\.)?__init__\(\) got an unexpected keyword argument "
+            rf"({cls_name}\.)?__init__\(\) got an unexpected keyword argument "
             "'invalid_arg'"
         )
     ):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -8,13 +8,23 @@ from mandible.metadata_mapper.storage import (
     STORAGE_REGISTRY,
     LocalFile,
     S3File,
+    Storage,
     StorageError,
 )
 
 
 def test_registry():
-    assert STORAGE_REGISTRY.get("LocalFile") is LocalFile
-    assert STORAGE_REGISTRY.get("S3File") is S3File
+    assert STORAGE_REGISTRY == {
+        "LocalFile": LocalFile,
+        "S3File": S3File,
+    }
+
+
+def test_registry_intermediate_class():
+    class Foo(Storage, register=False):
+        pass
+
+    assert "Foo" not in STORAGE_REGISTRY
 
 
 def test_registry_error():

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,6 +6,7 @@ import pytest
 from mandible.metadata_mapper.context import Context
 from mandible.metadata_mapper.storage import (
     STORAGE_REGISTRY,
+    Dummy,
     LocalFile,
     S3File,
     Storage,
@@ -15,6 +16,7 @@ from mandible.metadata_mapper.storage import (
 
 def test_registry():
     assert STORAGE_REGISTRY == {
+        "Dummy": Dummy,
         "LocalFile": LocalFile,
         "S3File": S3File,
     }

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>4
 isolated_build = true
-env_list = py{38,39,310,311}-X{all,none}
+env_list = py{38,39,310,311}-X{all,none}, py38-Xall-jp{14,15,16}
 
 [gh-actions]
 python =
@@ -18,6 +18,9 @@ deps =
     moto~=4.0
     pytest~=7.1
     pytest-mock~=3.8.2
+    jp14: jsonpath-ng~=1.4.0
+    jp15: jsonpath-ng~=1.5.0
+    jp16: jsonpath-ng~=1.6.0
 extras =
     Xnone:
     Xall: all

--- a/tox.ini
+++ b/tox.ini
@@ -22,5 +22,5 @@ extras =
     Xnone:
     Xall: all
 commands =
-    Xnone: pytest tests/ -m "not h5 and not xml" {posargs}
+    Xnone: pytest tests/ -m "not h5 and not xml and not jsonpath" {posargs}
     Xall: pytest tests/ {posargs}


### PR DESCRIPTION
We will need to be able to parse some fields pulled from ISO files as JSON since they contain list data which can't be encoded properly into the ISO as a list. For instance the input granules will come in as an additional attribute in the ISO with a JSON value.

This PR adds a new directive called `@reformatted` which lets you apply a new `Format` to a `str` or `bytes` value.

The template to use it looks like this:
```json
{
    "@reformatted": {
        "format": "Json",
        "value": {
            "@mapped": {
                "source": "file",
                "key": "/root/json-field"
            },
        },
        "key": "foo"
    },
}
```

Here the key `/root/json-field` will be extracted from the source `file`, and then be reformatted to `Json` returning the key `foo` from the parsed JSON structure.

These `@reformatted` directives can be nested arbitrarily many times.