### PR TITLE
PR-5929 Add zip file support

### DIFF
--- a/mandible/metadata_mapper/format/__init__.py
+++ b/mandible/metadata_mapper/format/__init__.py
@@ -1,4 +1,4 @@
-from .format import FORMAT_REGISTRY, Format, FormatError, Json, Zip
+from .format import FORMAT_REGISTRY, Format, FormatError, Json, SimpleFormat, Zip
 
 try:
     from .h5 import H5
@@ -17,6 +17,7 @@ __all__ = (
     "FormatError",
     "H5",
     "Json",
+    "SimpleFormat",
     "Xml",
     "Zip",
 )

--- a/mandible/metadata_mapper/format/__init__.py
+++ b/mandible/metadata_mapper/format/__init__.py
@@ -1,4 +1,4 @@
-from .format import FORMAT_REGISTRY, Format, FormatError, Json
+from .format import FORMAT_REGISTRY, Format, FormatError, Json, Zip
 
 try:
     from .h5 import H5
@@ -18,4 +18,5 @@ __all__ = (
     "H5",
     "Json",
     "Xml",
+    "Zip",
 )

--- a/mandible/metadata_mapper/format/__init__.py
+++ b/mandible/metadata_mapper/format/__init__.py
@@ -1,4 +1,12 @@
-from .format import FORMAT_REGISTRY, Format, FormatError, Json, SimpleFormat, Zip
+from .format import (
+    FORMAT_REGISTRY,
+    Format,
+    FormatError,
+    Json,
+    SimpleFormat,
+    Zip,
+    ZipInfo,
+)
 
 try:
     from .h5 import H5
@@ -20,4 +28,5 @@ __all__ = (
     "SimpleFormat",
     "Xml",
     "Zip",
+    "ZipInfo",
 )

--- a/mandible/metadata_mapper/format/format.py
+++ b/mandible/metadata_mapper/format/format.py
@@ -28,20 +28,24 @@ class Format(ABC):
         super().__init_subclass__(**kwargs)
 
     # Begin class definition
-    def get_values(self, file: IO[bytes], keys: Iterable[str]):
+    def get_values(
+        self,
+        file: IO[bytes],
+        keys: Iterable[str],
+    ) -> Dict[str, Any]:
         with self._parse_data(file) as data:
             return {
                 key: self._eval_key_wrapper(data, key)
                 for key in keys
             }
 
-    def get_value(self, file: IO[bytes], key: str):
+    def get_value(self, file: IO[bytes], key: str) -> Any:
         """Convenience function for getting a single value"""
 
         with self._parse_data(file) as data:
             return self._eval_key_wrapper(data, key)
 
-    def _eval_key_wrapper(self, data, key: str):
+    def _eval_key_wrapper(self, data, key: str) -> Any:
         try:
             return self._eval_key(data, key)
         except KeyError as e:
@@ -56,7 +60,7 @@ class Format(ABC):
 
     @staticmethod
     @abstractmethod
-    def _eval_key(data, key: str):
+    def _eval_key(data, key: str) -> Any:
         pass
 
 

--- a/mandible/metadata_mapper/format/format.py
+++ b/mandible/metadata_mapper/format/format.py
@@ -197,3 +197,27 @@ class Zip(Format):
                 return False
 
         return True
+
+
+@dataclass
+class ZipInfo(SimpleFormat):
+    @staticmethod
+    @contextlib.contextmanager
+    def _parse_data(file: IO[bytes]):
+        with zipfile.ZipFile(file, "r") as zf:
+            yield {
+                "infolist": [
+                    {
+                        k: getattr(info, k)
+                        for k in info.__slots__
+                        if not k.startswith("_")
+                    }
+                    for info in zf.infolist()
+                ],
+                "filename": zf.filename,
+                "comment": zf.comment,
+            }
+
+    @staticmethod
+    def _eval_key(data: dict, key: str):
+        return jsonpath.get_key(data, key)

--- a/mandible/metadata_mapper/format/h5.py
+++ b/mandible/metadata_mapper/format/h5.py
@@ -5,11 +5,11 @@ import h5py
 
 from mandible.h5_parser import normalize
 
-from .format import Format
+from .format import SimpleFormat
 
 
 @dataclass
-class H5(Format):
+class H5(SimpleFormat):
     @staticmethod
     def _parse_data(file: IO[bytes]) -> ContextManager[Any]:
         return h5py.File(file, "r")

--- a/mandible/metadata_mapper/format/h5.py
+++ b/mandible/metadata_mapper/format/h5.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import IO, Any, ContextManager
 
 import h5py
@@ -7,6 +8,7 @@ from mandible.h5_parser import normalize
 from .format import Format
 
 
+@dataclass
 class H5(Format):
     @staticmethod
     def _parse_data(file: IO[bytes]) -> ContextManager[Any]:

--- a/mandible/metadata_mapper/format/xml.py
+++ b/mandible/metadata_mapper/format/xml.py
@@ -1,4 +1,5 @@
 import contextlib
+from dataclasses import dataclass
 from typing import IO, Any
 
 from lxml import etree
@@ -6,6 +7,7 @@ from lxml import etree
 from .format import Format
 
 
+@dataclass
 class Xml(Format):
     @staticmethod
     @contextlib.contextmanager

--- a/mandible/metadata_mapper/format/xml.py
+++ b/mandible/metadata_mapper/format/xml.py
@@ -4,11 +4,11 @@ from typing import IO, Any
 
 from lxml import etree
 
-from .format import Format
+from .format import SimpleFormat
 
 
 @dataclass
-class Xml(Format):
+class Xml(SimpleFormat):
     @staticmethod
     @contextlib.contextmanager
     def _parse_data(file: IO[bytes]) -> Any:

--- a/mandible/metadata_mapper/storage.py
+++ b/mandible/metadata_mapper/storage.py
@@ -106,6 +106,8 @@ class LocalFile(FilteredStorage):
 
 @dataclass
 class S3File(FilteredStorage):
+    s3fs_kwargs: Dict[str, Any] = field(default_factory=dict)
+
     def _open_file(self, info: Dict) -> IO[bytes]:
-        s3 = s3fs.S3FileSystem(anon=False)
+        s3 = s3fs.S3FileSystem(anon=False, **self.s3fs_kwargs)
         return s3.open(f"s3://{info['bucket']}/{info['key']}")

--- a/mandible/metadata_mapper/storage.py
+++ b/mandible/metadata_mapper/storage.py
@@ -54,7 +54,7 @@ class FilteredStorage(Storage, register=False):
     returns data from the matching file.
     """
     # Begin class definition
-    filters: Dict[str, str] = field(default_factory=dict)
+    filters: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         self._compiled_filters = {

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -115,6 +115,31 @@ def test_s3_file_s3uri(s3_resource):
         assert f.read() == b"Some remote file content\n"
 
 
+def test_s3_file_s3fs_kwargs(s3_resource):
+    bucket = s3_resource.Bucket("test-bucket")
+    bucket.create()
+    obj = bucket.Object("bucket_file.txt")
+    obj.upload_fileobj(io.BytesIO(b"Some remote file content\n"))
+
+    context = Context(
+        files=[{
+            "name": "s3_file",
+            "bucket": "test-bucket",
+            "key": "bucket_file.txt"
+        }]
+    )
+    storage = S3File(
+        filters={"name": "s3_file"},
+        s3fs_kwargs={
+            "default_block_size": 64 * 1024,
+            "use_ssl": False,
+        },
+    )
+
+    with storage.open_file(context) as f:
+        assert f.read() == b"Some remote file content\n"
+
+
 def test_s3_file_filters(s3_resource):
     bucket = s3_resource.Bucket("test-bucket")
     bucket.create()


### PR DESCRIPTION
Since our existing framework already uses `s3fs` it's actually quite easy to integrate Zip support using the builtin `zipfile` module. 

I need to try this out with some large zip files and compare how the performance is vs `remotezip`. I believe `s3fs` + `zipfile` should be functionally quite similar to `remotezip` since the way `remotezip` is implemented is by creating a proxy file object that will make range requests, and plugging that into the standard `zipfile`. So the only question really is, how similar are the `remotezip` and `s3fs` implementations of the proxy file object.

Example Zip File:
```
128mb memory:
    s3fs + zip: 2.828s (affected by lambda cold start?)
    remotezip:  0.177s
512mb memory:
    s3fs + zip: 0.820s
    remotezip:  0.117s

Calls / bytes loaded:
    s3fs + zip: 4 requests 5,243,112 bytes
    remotezip:  2 requests 65,666 bytes
```

Remotezip is definitely more efficient, however, I think s3fs will still work fine. The main reason that s3fs is a lot slower, especially in the low memory environment, is because it has a `default_block_size` value of 5MB, which means one of the 'read' calls done by zip results in 5MB of data being downloaded and cached even if only a small amount of that is actually needed. Remotezip seems to limit this to 64KB which probably comes from the `initial_buffer_size` parameter of `RemoteIO`.

With a bit of tweaking, I suspect I can get the times to get quite close simply by lowering the `default_block_size`. This would be good to keep in mind because if we know that we're expecting the archive member we're extracting to have a certain size, we could set that parameter accordingly to avoid downloading those extra few megabytes of data surrounding it.

I think I will modify the `S3File` storage implementation to expose the additional s3fs configuration options.

After setting the `default_block_size` to 65Kb and running the lambda a few times to avoid measuring slowness due to cold start the timings got a lot closer. I also started measuring the time required to set up the Auth object for remotezip which I wasn't doing before which was skewing the results a bit:

```
512mb memory:
    s3fs + zip: 0.332s
    remotezip:  0.208s
```