### PR TITLE
PR-5948 Refactor ConfigSourceProvider and allow alternate Source implementations

### DIFF
--- a/mandible/metadata_mapper/__init__.py
+++ b/mandible/metadata_mapper/__init__.py
@@ -1,7 +1,7 @@
 from .context import Context
 from .format import Format
 from .mapper import MetadataMapper, MetadataMapperError
-from .source import ConfigSourceProvider, PySourceProvider, Source
+from .source import ConfigSourceProvider, FileSource, PySourceProvider
 
 __all__ = [
     "ConfigSourceProvider",
@@ -10,5 +10,5 @@ __all__ = [
     "MetadataMapper",
     "MetadataMapperError",
     "PySourceProvider",
-    "Source",
+    "FileSource",
 ]

--- a/mandible/metadata_mapper/format/__init__.py
+++ b/mandible/metadata_mapper/format/__init__.py
@@ -1,11 +1,11 @@
 from .format import (
     FORMAT_REGISTRY,
+    FileFormat,
     Format,
     FormatError,
     Json,
-    SimpleFormat,
-    Zip,
     ZipInfo,
+    ZipMember,
 )
 
 try:
@@ -21,12 +21,12 @@ except ImportError:
 
 __all__ = (
     "FORMAT_REGISTRY",
+    "FileFormat",
     "Format",
     "FormatError",
     "H5",
     "Json",
-    "SimpleFormat",
     "Xml",
-    "Zip",
     "ZipInfo",
+    "ZipMember",
 )

--- a/mandible/metadata_mapper/format/h5.py
+++ b/mandible/metadata_mapper/format/h5.py
@@ -6,17 +6,17 @@ import numpy as np
 
 from mandible.metadata_mapper.key import Key
 
-from .format import SimpleFormat
+from .format import FileFormat
 
 
 @dataclass
-class H5(SimpleFormat):
+class H5(FileFormat):
     @staticmethod
-    def _parse_data(file: IO[bytes]) -> ContextManager[Any]:
+    def parse_data(file: IO[bytes]) -> ContextManager[Any]:
         return h5py.File(file, "r")
 
     @staticmethod
-    def _eval_key(data, key: Key) -> Any:
+    def eval_key(data, key: Key) -> Any:
         return normalize(data[key.key][()])
 
 

--- a/mandible/metadata_mapper/format/xml.py
+++ b/mandible/metadata_mapper/format/xml.py
@@ -6,18 +6,18 @@ from lxml import etree
 
 from mandible.metadata_mapper.key import Key
 
-from .format import SimpleFormat
+from .format import FileFormat
 
 
 @dataclass
-class Xml(SimpleFormat):
+class Xml(FileFormat):
     @staticmethod
     @contextlib.contextmanager
-    def _parse_data(file: IO[bytes]) -> Any:
+    def parse_data(file: IO[bytes]) -> Any:
         yield etree.parse(file)
 
     @staticmethod
-    def _eval_key(data: etree.ElementTree, key: Key) -> Any:
+    def eval_key(data: etree.ElementTree, key: Key) -> Any:
         nsmap = data.getroot().nsmap
         elements = data.xpath(key.key, namespaces=nsmap)
         values = [element.text for element in elements]

--- a/mandible/metadata_mapper/source.py
+++ b/mandible/metadata_mapper/source.py
@@ -1,9 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, Set, Type, TypeVar
-
-from mandible.internal import Registry
+from typing import Any, Dict, Optional, Set, Type, TypeVar
 
 from .context import Context
 from .format import FORMAT_REGISTRY, Format
@@ -14,18 +12,44 @@ log = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+SOURCE_REGISTRY: Dict[str, Type["Source"]] = {}
+
+REGISTRY_TYPE_MAP = {
+    "Format": FORMAT_REGISTRY,
+    "Storage": STORAGE_REGISTRY,
+    "Source": SOURCE_REGISTRY,
+}
+
 
 @dataclass
-class Source:
-    storage: Storage
-    format: Format
+class Source(ABC):
+    # Registry boilerplate
+    def __init_subclass__(cls, register: bool = True, **kwargs):
+        if register:
+            SOURCE_REGISTRY[cls.__name__] = cls
 
+        super().__init_subclass__(**kwargs)
+
+    # Begin class definition
     def __post_init__(self):
         self._keys: Set[Key] = set()
         self._values: Dict[Key, Any] = {}
 
     def add_key(self, key: Key):
         self._keys.add(key)
+
+    @abstractmethod
+    def query_all_values(self, context: Context):
+        pass
+
+    def get_value(self, key: Key):
+        return self._values[key]
+
+
+@dataclass
+class FileSource(Source):
+    storage: Storage
+    format: Format
 
     def query_all_values(self, context: Context):
         if not self._keys:
@@ -41,9 +65,6 @@ class Source:
                 new_values
             )
             self._values.update(new_values)
-
-    def get_value(self, key: Key):
-        return self._values[key]
 
 
 class SourceProviderError(Exception):
@@ -79,64 +100,75 @@ class ConfigSourceProvider(SourceProvider):
         }
 
     def _create_source(self, key: str, config: Dict) -> Source:
+        cls_name = config.get("class") or FileSource.__name__
+        cls = SOURCE_REGISTRY.get(cls_name)
+        if cls is None:
+            raise SourceProviderError(f"{key} invalid source type {repr(cls_name)}")
+
         try:
-            return Source(
-                storage=self._create_from_registry(
-                    STORAGE_REGISTRY,
-                    config,
-                    "storage"
-                ),
-                format=self._create_from_registry(
-                    FORMAT_REGISTRY,
-                    config,
-                    "format"
-                )
-            )
+            return self._instantiate_class(cls, config)
         except Exception as e:
             raise SourceProviderError(
                 f"failed to create source {repr(key)}: {e}",
             ) from e
 
-    def _create_from_registry(
+    def _create_object(
         self,
-        registry: Registry[Type[T]],
-        config: Dict[str, Any],
-        name_key: str
-    ) -> T:
-        class_config = config.get(name_key)
-        if class_config is None:
-            raise SourceProviderError(f"missing key {repr(name_key)} in config")
-
-        cls_name = class_config.get("class")
+        parent_cls: Type[Any],
+        key: str,
+        config: Dict,
+    ) -> Any:
+        cls_name = config.get("class")
         if cls_name is None:
             raise SourceProviderError(
-                f"missing key 'class' in config {class_config}"
+                f"missing key 'class' in config {config}"
             )
 
-        cls = registry.get(cls_name)
+        # TODO(reweeden): As of python3.10, inspect.get_annotations(parent_cls)
+        # should be used instead here.
+        base_cls = parent_cls.__annotations__[key]
+
+        cls = self._get_class_from_registry(base_cls, cls_name)
         if cls is None:
-            raise SourceProviderError(f"invalid {name_key} type {repr(cls_name)}")
+            raise SourceProviderError(f"invalid {key} type {repr(cls_name)}")
 
-        return self._create_class(cls, class_config)
+        if not issubclass(cls, base_cls):
+            raise SourceProviderError(
+                f"invalid {key} type {repr(cls_name)} must be a subclass of "
+                f"{repr(base_cls.__name__)}",
+            )
 
-    def _create_class(self, cls: Type[T], config: Dict[str, Any]) -> T:
+        return self._instantiate_class(cls, config)
+
+    def _get_class_from_registry(
+        self,
+        base_cls: Type[Any],
+        cls_name: str,
+    ) -> Optional[Type[Any]]:
+        cls = REGISTRY_TYPE_MAP.get(base_cls.__name__, {}).get(cls_name)
+
+        if cls is None:
+            for parent_base_cls in base_cls.__mro__:
+                cls = REGISTRY_TYPE_MAP.get(
+                    parent_base_cls.__name__,
+                    {},
+                ).get(cls_name)
+                if cls is not None:
+                    break
+
+        return cls
+
+    def _instantiate_class(self, cls: Type[T], config: Dict[str, Any]) -> T:
         kwargs = {
-            k: self._convert_arg(k, v)
+            k: self._convert_arg(cls, k, v)
             for k, v in config.items()
             if k != "class"
         }
 
         return cls(**kwargs)
 
-    def _convert_arg(self, name_key: str, arg: Any) -> Any:
+    def _convert_arg(self, parent_cls: Type[Any], key: str, arg: Any) -> Any:
         if isinstance(arg, dict) and "class" in arg:
-            cls_name = arg["class"]
-
-            # Only support Format classes for now
-            format_cls = FORMAT_REGISTRY.get(cls_name)
-            if format_cls:
-                return self._create_class(format_cls, arg)
-
-            raise SourceProviderError(f"invalid {name_key} type {repr(cls_name)}")
+            return self._create_object(parent_cls, key, arg)
 
         return arg

--- a/mandible/metadata_mapper/storage.py
+++ b/mandible/metadata_mapper/storage.py
@@ -24,6 +24,7 @@ class Storage(ABC):
 
         super().__init_subclass__(**kwargs)
 
+    # Begin class definition
     @abstractmethod
     def open_file(self, context: Context) -> IO[bytes]:
         """Get a filelike object to access the data."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.6.1"
+version = "0.7.0"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"

--- a/tests/integration_tests/test_metadata_mapper.py
+++ b/tests/integration_tests/test_metadata_mapper.py
@@ -5,10 +5,10 @@ import pytest
 from mandible.metadata_mapper import (
     ConfigSourceProvider,
     Context,
+    FileSource,
     MetadataMapper,
     MetadataMapperError,
     PySourceProvider,
-    Source,
 )
 from mandible.metadata_mapper.format import Json, Xml
 from mandible.metadata_mapper.storage import LocalFile
@@ -123,7 +123,7 @@ def test_basic_py_source_provider(config, context):
     mapper = MetadataMapper(
         template=config["template"],
         source_provider=PySourceProvider({
-            "fixed_name_file": Source(
+            "fixed_name_file": FileSource(
                 storage=LocalFile(
                     filters={
                         "name": "fixed_name_file.json",
@@ -131,7 +131,7 @@ def test_basic_py_source_provider(config, context):
                 ),
                 format=Json(),
             ),
-            "fixed_xml_file": Source(
+            "fixed_xml_file": FileSource(
                 storage=LocalFile(
                     filters={
                         "name": "fixed_xml_file.xml",
@@ -139,7 +139,7 @@ def test_basic_py_source_provider(config, context):
                 ),
                 format=Xml(),
             ),
-            "namespace_xml_file": Source(
+            "namespace_xml_file": FileSource(
                 storage=LocalFile(
                     filters={
                         "name": "xml_with_namespace.xml",
@@ -147,7 +147,7 @@ def test_basic_py_source_provider(config, context):
                 ),
                 format=Xml(),
             ),
-            "name_match_file": Source(
+            "name_match_file": FileSource(
                 storage=LocalFile(
                     filters={
                         "name": r".*match_me\.json",
@@ -155,7 +155,7 @@ def test_basic_py_source_provider(config, context):
                 ),
                 format=Json(),
             ),
-            "name_match_file2": Source(
+            "name_match_file2": FileSource(
                 storage=LocalFile(
                     filters={
                         "name": re.compile(r".*match_me\.json"),

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from mandible.metadata_mapper import Context, Source
+from mandible.metadata_mapper import Context, FileSource
 from mandible.metadata_mapper.builder import _DIRECTIVE_BUILDER_REGISTRY
 from mandible.metadata_mapper.directive import (
     DIRECTIVE_REGISTRY,
@@ -28,7 +28,7 @@ def test_mapped_mutually_exclusive_key_options():
     with pytest.raises(ValueError, match="cannot set both"):
         Mapped(
             context=Context(),
-            sources={"source": mock.create_autospec(Source)},
+            sources={"source": mock.create_autospec(FileSource)},
             source="source",
             key="key",
             key_options={

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -11,8 +11,8 @@ from mandible.metadata_mapper.format import (
     FormatError,
     Json,
     Xml,
-    Zip,
     ZipInfo,
+    ZipMember,
 )
 from mandible.metadata_mapper.key import Key
 
@@ -27,8 +27,8 @@ def test_registry():
         "H5": H5,
         "Json": Json,
         "Xml": Xml,
-        "Zip": Zip,
         "ZipInfo": ZipInfo,
+        "ZipMember": ZipMember,
     }
 
 
@@ -180,7 +180,7 @@ def test_zip():
             """,
         )
 
-    format = Zip(
+    format = ZipMember(
         filters={
             "filename": "foo",
         },
@@ -208,7 +208,7 @@ def test_zip_filters():
             """,
         )
 
-    format = Zip(
+    format = ZipMember(
         filters={
             "filename": "^foo$",
         },
@@ -227,7 +227,7 @@ def test_zip_filters_bad_attribute():
         f.writestr("unformatted.txt", "This is just some text/n")
         f.writestr("foobar.txt", "This is some foo text")
 
-    format = Zip(
+    format = ZipMember(
         filters={
             "filename": "^foo$",
             "nonexistent_attr": True,

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,10 +1,11 @@
 import io
+from dataclasses import dataclass
 from unittest import mock
 
 import pytest
 
+from mandible.metadata_mapper import FileSource, Format
 from mandible.metadata_mapper.context import Context
-from mandible.metadata_mapper.format import Format
 from mandible.metadata_mapper.key import Key
 from mandible.metadata_mapper.source import Source
 from mandible.metadata_mapper.storage import Storage
@@ -32,9 +33,9 @@ def test_source(mock_context, mock_format, mock_storage):
         Key("bar"): "bar value",
     }
 
-    source = Source(
+    source = FileSource(
         mock_storage,
-        mock_format
+        mock_format,
     )
 
     source.add_key(Key("foo"))
@@ -50,12 +51,33 @@ def test_source(mock_context, mock_format, mock_storage):
 
 
 def test_source_query_no_keys(mock_context, mock_format, mock_storage):
-    source = Source(
+    source = FileSource(
         mock_storage,
-        mock_format
+        mock_format,
     )
 
     source.query_all_values(mock_context)
 
     mock_storage.open_file.assert_not_called()
     mock_format.get_values.assert_not_called()
+
+
+def test_custom_source(mock_context):
+    @dataclass
+    class CustomSource(Source):
+        arg1: str
+
+        def query_all_values(self, context: Context):
+            self._values.update({
+                key: key.key
+                for key in self._keys
+            })
+
+    source = CustomSource("foo")
+    source.add_key(Key("hello"))
+
+    source.query_all_values(mock_context)
+
+    assert source._values == {
+        Key("hello"): "hello",
+    }


### PR DESCRIPTION
This would allow us to implement a `Source` that queries an s3 object through `select_object_content` instead of using s3fs.

There is a possible alternate implementation where we could use the existing `Source` and create a new `Storage` and `Format` pair that work together. But I feel that this is clunkier as those new `Storage`/`Format` classes would completely break if you tried to use them with any other non-matching `Storage` or `Format` implementations. This just puts more requirements on the user of mandible to know how to set up the config correctly because mandible isn't able to validate such requirements.