### PR TITLE
PR-5946 add custom record factory support

### DIFF
--- a/mandible/log.py
+++ b/mandible/log.py
@@ -9,12 +9,12 @@ from typing import Type
 class JSONFormatter(logging.Formatter):
     def format(self, record):
         log_record = {
-            'timestamp': self.formatTime(record, self.datefmt),
-            'level': record.levelname,
-            'message': record.getMessage(),
-            'line_no': record.lineno,
-            'exception': self.formatException(record.exc_info) if record.exc_info else None,
-            'extra': record.__dict__.get('extra', {})
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "line_no": record.lineno,
+            "exception": self.formatException(record.exc_info) if record.exc_info else None,
+            "extra": record.__dict__.get("extra", {})
         }
         return json.dumps(log_record)
 
@@ -27,12 +27,27 @@ def log_with_extra(extra=None):
         @wraps(func)
         def wrapper(*args, **kwargs):
             if callable(extra):
-                kwargs['extra'] = extra()
+                kwargs["extra"] = extra()
             else:
-                kwargs['extra'] = extra
+                kwargs["extra"] = extra
             return func(*args, **kwargs)
         return wrapper
     return decorator
+
+
+def inject_cumulus_extras(event, context: dict) -> dict:
+    return {
+        "daac_version": os.getenv("DAAC_VERSION"),
+        "core_Version": os.getenv("CORE_VERSION"),
+        "step_function_name": event.cumulus_meta.execution_name,
+        "cumulus_version": event.cumulus_meta.cumulus_version,
+        "aws_request_id": context.aws_request_id,
+        "function_name": context.function_name,
+        "memory_limit_in_mb": context.memory_limit_in_mb,
+        "invoked_function_arn": context.invoked_function_arn,
+        "log_group_name": context.log_group_name,
+        "log_stream_name": context.log_stream_name,
+    }
 
 
 def init_json_formatter():

--- a/mandible/log.py
+++ b/mandible/log.py
@@ -1,7 +1,21 @@
+import json
 import logging
 import os
 from contextlib import contextmanager
 from typing import Type
+
+class JSONFormatter(logging.Formatter):
+    def format(self, record):
+        log_record = {
+            'timestamp': self.formatTime(record, self.datefmt),
+            'level': record.levelname,
+            'message': record.getMessage(),
+            'line_no': record.lineno,
+            'exception': self.formatException(record.exc_info) if record.exc_info else None,
+            'extra': record.__dict__.get('extra', {})
+        }
+        return json.dumps(log_record)
+
 
 
 def init_root_logger():

--- a/mandible/log.py
+++ b/mandible/log.py
@@ -31,6 +31,16 @@ def log_with_extra(extra=None):
         return wrapper
     return decorator
 
+
+def init_json_formatter():
+    log = logging.getLogger(__name__)
+    handler = logging.StreamHandler()
+    formatter = JSONFormatter()
+
+    handler.setFormatter(formatter)
+    log.addHandler(handler)
+
+
 def init_root_logger():
     """Set up log levels for lambda using the environment variable"""
     level = os.getenv("LOG_LEVEL", logging.INFO)

--- a/mandible/log.py
+++ b/mandible/log.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from contextlib import contextmanager
-from typing import Type
+from typing import Callable, Type
 
 
 def _build_cumulus_extras_from_cma(event: dict) -> dict:
@@ -15,17 +15,22 @@ def _build_cumulus_extras_from_cma(event: dict) -> dict:
     }
 
 
-def init_cma_log_record_factory(event: dict, record_builder: callable = _build_cumulus_extras_from_cma) -> None:
+def init_custom_log_record_factory(
+    event: dict,
+    record_builder: Callable[[dict], dict] = _build_cumulus_extras_from_cma,
+) -> None:
     """
         configures the logging record factory and can be overwritten by providing a function that takes the event dict
         as an input and returns a dict of log records.
         Relies on the JSON formatter setting provided by AWS.
-        By default this provides:
+        By default the callable returns:
+        {
             "cirrus_daac_version": os.getenv("DAAC_VERSION"),
             "cirrus_core_version": os.getenv("CORE_VERSION"),
             "cumulus_version": event.get("cumulus_meta", {}).get("cumulus_version"),
             "granule_name": event.get("payload", {}).get("granules", [{}])[0].get("granuleId"),
             "workflow_execution_name": event.get("cumulus_meta", {}).get("execution_name"),
+        }
     """
     extra = record_builder(event)
     original_factory = logging.getLogRecordFactory()

--- a/mandible/log.py
+++ b/mandible/log.py
@@ -20,13 +20,16 @@ class JSONFormatter(logging.Formatter):
 
 
 def log_with_extra(extra=None):
-    if not isinstance(extra, dict):
-        raise TypeError("Extra must be a dictionary.")
+    if extra is not None and not (isinstance(extra, dict) or callable(extra)):
+        raise TypeError("Extra must be a dictionary or callable.")
 
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            kwargs['extra'] = extra
+            if callable(extra):
+                kwargs['extra'] = extra()
+            else:
+                kwargs['extra'] = extra
             return func(*args, **kwargs)
         return wrapper
     return decorator

--- a/mandible/log.py
+++ b/mandible/log.py
@@ -2,7 +2,9 @@ import json
 import logging
 import os
 from contextlib import contextmanager
+from functools import wraps
 from typing import Type
+
 
 class JSONFormatter(logging.Formatter):
     def format(self, record):
@@ -17,6 +19,17 @@ class JSONFormatter(logging.Formatter):
         return json.dumps(log_record)
 
 
+def log_with_extra(extra=None):
+    if not isinstance(extra, dict):
+        raise TypeError("Extra must be a dictionary.")
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            kwargs['extra'] = extra
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
 
 def init_root_logger():
     """Set up log levels for lambda using the environment variable"""

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,6 +1,39 @@
+import logging
+
 import pytest
 
-from mandible.log import log_errors
+from mandible.log import init_custom_log_record_factory, log_errors
+
+
+@pytest.fixture
+def event_config():
+    return {
+        "cma": {
+            "event": {
+                "cumulus_meta": {
+                    "execution_name": "this_is_a_test_execution",
+                    "cumulus_version": "TEST_CUMULUS",
+                },
+                "payload": {
+                    "granules": [{"granuleId": "test_granule"}],
+                },
+            },
+        },
+    }
+
+
+def test_custom_log_record_factory(caplog, monkeypatch, event_config):
+    monkeypatch.setenv("DAAC_VERSION", "TEST_DAAC")
+    monkeypatch.setenv("CORE_VERSION", "TEST_CORE")
+    with caplog.at_level(logging.INFO):
+        log = logging.getLogger(__name__)
+        init_custom_log_record_factory(event_config)
+        log.info("TEST")
+        assert caplog.records[0].cirrus_daac_version == "TEST_DAAC"
+        assert caplog.records[0].cirrus_core_version == "TEST_CORE"
+        assert caplog.records[0].cumulus_version == "TEST_CUMULUS"
+        assert caplog.records[0].granule_name == "test_granule"
+        assert caplog.records[0].workflow_execution_name == "this_is_a_test_execution"
 
 
 def test_log_errors(caplog):


### PR DESCRIPTION
UPDATE:
AWS released a Lambda config that sets up a formatter automatically and it handles what ever the current record. This simplifies the system in mandible to only needing a custom log record factory function. I have created a basic one but the function can be passed a custom callable to enable any future customizations. 

This greatly simplifies what mandible does and moves a little TF work to the NISAR and ASF PRs.  Because our provider is up to date, I was able to implement the TF changes easily through the new lambda config block logging_configuration.
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#logging_config

https://aws.amazon.com/about-aws/whats-new/2024/07/aws-lambda-search-filter-aggregate-function-logs/

Keeping the info below for historical purposes
----------------------------------
This is in a tested state from my branch on cirrus-nisar. I am curious what peoples thoughts are. 
I wanted to make the decorator except any callable but that proved to be more complex and was having trouble getting the record to be updated. 

It is currently a simple record that is couple to cumulus which may indicate a new name is needed and a decorator to inject the things we need into messages. 

CORE and DAAC version come from ENV vars and the Cumulus version, granule name, step function name come from the event input. 

I tested a version that made a function to setup the logger, but decided it was reasonable to do it at the start of each file. 

Here is an example utilizing this setup.
https://github.com/asfadmin/CIRRUS-NISAR/blob/mrp/feature/structured-log-messages/workflows/nisar/lambdas/nisar_lambdas/get_cnm.py

The PR to NISAR will come post this merging. 

