### PR TITLE
PR-6293 Add storage for querying CMR

### DIFF
--- a/mandible/jsonpath.py
+++ b/mandible/jsonpath.py
@@ -8,11 +8,11 @@ except ImportError:
 def get(data: dict, path: str) -> list:
     # Fall back to simple dot paths
     if jsonpath_ng is None:
-        if path == "$":
-            return [data]
-
         val = data
         for part in path.split("."):
+            if part == "$":
+                continue
+
             val = val[part]
 
         return [val]

--- a/mandible/metadata_mapper/__init__.py
+++ b/mandible/metadata_mapper/__init__.py
@@ -1,7 +1,8 @@
 from .context import Context
 from .format import Format
 from .mapper import MetadataMapper, MetadataMapperError
-from .source import ConfigSourceProvider, FileSource, PySourceProvider
+from .source import FileSource
+from .source_provider import ConfigSourceProvider, PySourceProvider
 
 __all__ = [
     "ConfigSourceProvider",

--- a/mandible/metadata_mapper/context.py
+++ b/mandible/metadata_mapper/context.py
@@ -1,8 +1,73 @@
+import dataclasses
 from dataclasses import dataclass, field
 from typing import Any
+
+from mandible import jsonpath
+
+from .exception import ContextValueError
 
 
 @dataclass
 class Context:
     files: list[dict[str, Any]] = field(default_factory=list)
-    meta: list[str, Any] = field(default_factory=dict)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ContextValue:
+    """A marker that should be replaced by a value from the Context"""
+
+    path: str
+
+
+def replace_context_values(
+    obj: Any,
+    context: Context,
+) -> Any:
+    return _replace_context_values(obj, dataclasses.asdict(context))
+
+
+def _replace_context_values(obj: Any, context_dict: dict) -> Any:
+    if isinstance(obj, ContextValue):
+        try:
+            result = jsonpath.get(context_dict, obj.path)
+        except Exception as e:
+            raise ContextValueError(
+                f"jsonpath error for path {repr(obj.path)}: {e}",
+            ) from e
+
+        if not result:
+            raise ContextValueError(
+                f"context missing value for path {repr(obj.path)}",
+            )
+        if len(result) > 1:
+            raise ContextValueError(
+                f"context path {repr(obj.path)} returned more than "
+                f"one value",
+            )
+
+        return result[0]
+
+    if isinstance(obj, dict):
+        return {
+            k: _replace_context_values(v, context_dict)
+            for k, v in obj.items()
+        }
+
+    if isinstance(obj, list):
+        return [_replace_context_values(v, context_dict) for v in obj]
+
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        replaced = dataclasses.replace(
+            obj,
+            **{
+                field_obj.name: _replace_context_values(
+                    getattr(obj, field_obj.name),
+                    context_dict,
+                )
+                for field_obj in dataclasses.fields(obj)
+            },
+        )
+        return replaced
+
+    return obj

--- a/mandible/metadata_mapper/exception.py
+++ b/mandible/metadata_mapper/exception.py
@@ -18,3 +18,22 @@ class TemplateError(MetadataMapperError):
             debug = f" at {self.debug_path}"
 
         return f"failed to process template{debug}: {self.msg}"
+
+
+class ContextValueError(MetadataMapperError):
+    """An error that occurred while processing the context value replacements."""
+
+    def __init__(
+        self,
+        msg: str,
+        source_name: str = None,
+    ):
+        super().__init__(msg)
+        self.source_name = source_name
+
+    def __str__(self) -> str:
+        debug = ""
+        if self.source_name is not None:
+            debug = f" for source {repr(self.source_name)}"
+
+        return f"failed to process context values{debug}: {self.msg}"

--- a/mandible/metadata_mapper/mapper.py
+++ b/mandible/metadata_mapper/mapper.py
@@ -5,7 +5,8 @@ from typing import Any, Optional
 from .context import Context
 from .directive import DIRECTIVE_REGISTRY, TemplateDirective
 from .exception import MetadataMapperError, TemplateError
-from .source import Source, SourceProvider
+from .source import Source
+from .source_provider import SourceProvider
 from .types import Template
 
 log = logging.getLogger(__name__)

--- a/mandible/metadata_mapper/mapper.py
+++ b/mandible/metadata_mapper/mapper.py
@@ -31,7 +31,7 @@ class MetadataMapper:
             sources = {}
 
         try:
-            self._cache_source_keys(context, sources)
+            self._prepare_directives(context, sources)
         except TemplateError:
             raise
         except Exception as e:
@@ -57,7 +57,7 @@ class MetadataMapper:
                 f"failed to evaluate template: {e}"
             ) from e
 
-    def _cache_source_keys(self, context: Context, sources: dict[str, Source]):
+    def _prepare_directives(self, context: Context, sources: dict[str, Source]):
         for value, debug_path in _walk_values(self.template):
             if isinstance(value, dict):
                 directive_name = self._get_directive_name(value, debug_path)

--- a/mandible/metadata_mapper/source.py
+++ b/mandible/metadata_mapper/source.py
@@ -1,24 +1,17 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Optional, TypeVar
+from typing import Any
 
 from .context import Context
-from .format import FORMAT_REGISTRY, Format
+from .format import Format
 from .key import Key
-from .storage import STORAGE_REGISTRY, Storage
+from .storage import Storage
 
 log = logging.getLogger(__name__)
 
-T = TypeVar("T")
 
 SOURCE_REGISTRY: dict[str, type["Source"]] = {}
-
-REGISTRY_TYPE_MAP = {
-    "Format": FORMAT_REGISTRY,
-    "Storage": STORAGE_REGISTRY,
-    "Source": SOURCE_REGISTRY,
-}
 
 
 @dataclass
@@ -65,110 +58,3 @@ class FileSource(Source):
                 new_values
             )
             self._values.update(new_values)
-
-
-class SourceProviderError(Exception):
-    pass
-
-
-class SourceProvider(ABC):
-    @abstractmethod
-    def get_sources(self) -> dict[str, Source]:
-        pass
-
-
-class PySourceProvider(SourceProvider):
-    """Dummy provider that passes sources through as a python object"""
-
-    def __init__(self, sources: dict[str, Source]):
-        self.sources = sources
-
-    def get_sources(self) -> dict[str, Source]:
-        return self.sources
-
-
-class ConfigSourceProvider(SourceProvider):
-    """Provide sources from JSON object config"""
-
-    def __init__(self, config: dict):
-        self.config = config
-
-    def get_sources(self) -> dict[str, Source]:
-        return {
-            key: self._create_source(key, config)
-            for key, config in self.config.items()
-        }
-
-    def _create_source(self, key: str, config: dict) -> Source:
-        cls_name = config.get("class") or FileSource.__name__
-        cls = SOURCE_REGISTRY.get(cls_name)
-        if cls is None:
-            raise SourceProviderError(f"{key} invalid source type {repr(cls_name)}")
-
-        try:
-            return self._instantiate_class(cls, config)
-        except Exception as e:
-            raise SourceProviderError(
-                f"failed to create source {repr(key)}: {e}",
-            ) from e
-
-    def _create_object(
-        self,
-        parent_cls: type[Any],
-        key: str,
-        config: dict,
-    ) -> Any:
-        cls_name = config.get("class")
-        if cls_name is None:
-            raise SourceProviderError(
-                f"missing key 'class' in config {config}"
-            )
-
-        # TODO(reweeden): As of python3.10, inspect.get_annotations(parent_cls)
-        # should be used instead here.
-        base_cls = parent_cls.__annotations__[key]
-
-        cls = self._get_class_from_registry(base_cls, cls_name)
-        if cls is None:
-            raise SourceProviderError(f"invalid {key} type {repr(cls_name)}")
-
-        if not issubclass(cls, base_cls):
-            raise SourceProviderError(
-                f"invalid {key} type {repr(cls_name)} must be a subclass of "
-                f"{repr(base_cls.__name__)}",
-            )
-
-        return self._instantiate_class(cls, config)
-
-    def _get_class_from_registry(
-        self,
-        base_cls: type[Any],
-        cls_name: str,
-    ) -> Optional[type[Any]]:
-        cls = REGISTRY_TYPE_MAP.get(base_cls.__name__, {}).get(cls_name)
-
-        if cls is None:
-            for parent_base_cls in base_cls.__mro__:
-                cls = REGISTRY_TYPE_MAP.get(
-                    parent_base_cls.__name__,
-                    {},
-                ).get(cls_name)
-                if cls is not None:
-                    break
-
-        return cls
-
-    def _instantiate_class(self, cls: type[T], config: dict[str, Any]) -> T:
-        kwargs = {
-            k: self._convert_arg(cls, k, v)
-            for k, v in config.items()
-            if k != "class"
-        }
-
-        return cls(**kwargs)
-
-    def _convert_arg(self, parent_cls: type[Any], key: str, arg: Any) -> Any:
-        if isinstance(arg, dict) and "class" in arg:
-            return self._create_object(parent_cls, key, arg)
-
-        return arg

--- a/mandible/metadata_mapper/source_provider.py
+++ b/mandible/metadata_mapper/source_provider.py
@@ -1,0 +1,124 @@
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Optional, TypeVar
+
+from .format import FORMAT_REGISTRY
+from .source import SOURCE_REGISTRY, FileSource, Source
+from .storage import STORAGE_REGISTRY
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+REGISTRY_TYPE_MAP = {
+    "Format": FORMAT_REGISTRY,
+    "Storage": STORAGE_REGISTRY,
+    "Source": SOURCE_REGISTRY,
+}
+
+
+class SourceProviderError(Exception):
+    pass
+
+
+class SourceProvider(ABC):
+    @abstractmethod
+    def get_sources(self) -> dict[str, Source]:
+        pass
+
+
+class PySourceProvider(SourceProvider):
+    """Dummy provider that passes sources through as a python object"""
+
+    def __init__(self, sources: dict[str, Source]):
+        self.sources = sources
+
+    def get_sources(self) -> dict[str, Source]:
+        return self.sources
+
+
+class ConfigSourceProvider(SourceProvider):
+    """Provide sources from JSON object config"""
+
+    def __init__(self, config: dict):
+        self.config = config
+
+    def get_sources(self) -> dict[str, Source]:
+        return {
+            key: self._create_source(key, config)
+            for key, config in self.config.items()
+        }
+
+    def _create_source(self, key: str, config: dict) -> Source:
+        cls_name = config.get("class") or FileSource.__name__
+        cls = SOURCE_REGISTRY.get(cls_name)
+        if cls is None:
+            raise SourceProviderError(f"{key} invalid source type {repr(cls_name)}")
+
+        try:
+            return self._instantiate_class(cls, config)
+        except Exception as e:
+            raise SourceProviderError(
+                f"failed to create source {repr(key)}: {e}",
+            ) from e
+
+    def _create_object(
+        self,
+        parent_cls: type[Any],
+        key: str,
+        config: dict,
+    ) -> Any:
+        cls_name = config.get("class")
+        if cls_name is None:
+            raise SourceProviderError(
+                f"missing key 'class' in config {config}"
+            )
+
+        # TODO(reweeden): As of python3.10, inspect.get_annotations(parent_cls)
+        # should be used instead here.
+        base_cls = parent_cls.__annotations__[key]
+
+        cls = self._get_class_from_registry(base_cls, cls_name)
+        if cls is None:
+            raise SourceProviderError(f"invalid {key} type {repr(cls_name)}")
+
+        if not issubclass(cls, base_cls):
+            raise SourceProviderError(
+                f"invalid {key} type {repr(cls_name)} must be a subclass of "
+                f"{repr(base_cls.__name__)}",
+            )
+
+        return self._instantiate_class(cls, config)
+
+    def _get_class_from_registry(
+        self,
+        base_cls: type[Any],
+        cls_name: str,
+    ) -> Optional[type[Any]]:
+        cls = REGISTRY_TYPE_MAP.get(base_cls.__name__, {}).get(cls_name)
+
+        if cls is None:
+            for parent_base_cls in base_cls.__mro__:
+                cls = REGISTRY_TYPE_MAP.get(
+                    parent_base_cls.__name__,
+                    {},
+                ).get(cls_name)
+                if cls is not None:
+                    break
+
+        return cls
+
+    def _instantiate_class(self, cls: type[T], config: dict[str, Any]) -> T:
+        kwargs = {
+            k: self._convert_arg(cls, k, v)
+            for k, v in config.items()
+            if k != "class"
+        }
+
+        return cls(**kwargs)
+
+    def _convert_arg(self, parent_cls: type[Any], key: str, arg: Any) -> Any:
+        if isinstance(arg, dict) and "class" in arg:
+            return self._create_object(parent_cls, key, arg)
+
+        return arg

--- a/mandible/metadata_mapper/source_provider.py
+++ b/mandible/metadata_mapper/source_provider.py
@@ -12,8 +12,8 @@ T = TypeVar("T")
 
 REGISTRY_TYPE_MAP = {
     "Format": FORMAT_REGISTRY,
-    "Storage": STORAGE_REGISTRY,
     "Source": SOURCE_REGISTRY,
+    "Storage": STORAGE_REGISTRY,
 }
 
 

--- a/mandible/metadata_mapper/storage/__init__.py
+++ b/mandible/metadata_mapper/storage/__init__.py
@@ -1,0 +1,19 @@
+from .storage import (
+    STORAGE_REGISTRY,
+    Dummy,
+    FilteredStorage,
+    LocalFile,
+    S3File,
+    Storage,
+    StorageError,
+)
+
+__all__ = (
+    "Dummy",
+    "FilteredStorage",
+    "LocalFile",
+    "S3File",
+    "STORAGE_REGISTRY",
+    "Storage",
+    "StorageError",
+)

--- a/mandible/metadata_mapper/storage/__init__.py
+++ b/mandible/metadata_mapper/storage/__init__.py
@@ -8,9 +8,16 @@ from .storage import (
     StorageError,
 )
 
+try:
+    from .http_request import HttpRequest
+except ImportError:
+    from .storage import HttpRequest
+
+
 __all__ = (
     "Dummy",
     "FilteredStorage",
+    "HttpRequest",
     "LocalFile",
     "S3File",
     "STORAGE_REGISTRY",

--- a/mandible/metadata_mapper/storage/__init__.py
+++ b/mandible/metadata_mapper/storage/__init__.py
@@ -9,12 +9,18 @@ from .storage import (
 )
 
 try:
+    from .cmr_query import CmrQuery
+except ImportError:
+    from .storage import CmrQuery
+
+try:
     from .http_request import HttpRequest
 except ImportError:
     from .storage import HttpRequest
 
 
 __all__ = (
+    "CmrQuery",
     "Dummy",
     "FilteredStorage",
     "HttpRequest",

--- a/mandible/metadata_mapper/storage/cmr_query.py
+++ b/mandible/metadata_mapper/storage/cmr_query.py
@@ -1,0 +1,46 @@
+import urllib.parse
+from dataclasses import InitVar, dataclass
+from typing import Optional
+
+from mandible.metadata_mapper.context import Context
+
+from .http_request import HttpRequest
+
+
+@dataclass
+class CmrQuery(HttpRequest):
+    """A convenience class for setting neccessary CMR parameters"""
+
+    url: InitVar[None] = None
+
+    base_url: str = ""
+    path: str = ""
+    format: str = ""
+    token: Optional[str] = None
+
+    def __post_init__(self, url: str):
+        if url:
+            raise ValueError(
+                "do not set 'url' directly, use 'base_url' and 'path' instead",
+            )
+
+    def _get_override_request_args(self, context: Context) -> dict:
+        return {
+            "headers": self._get_headers(),
+            "url": self._get_url(),
+        }
+
+    def _get_headers(self) -> Optional[dict]:
+        if self.token is None:
+            return self.headers
+
+        return {
+            **(self.headers or {}),
+            "Authorization": self.token,
+        }
+
+    def _get_url(self) -> str:
+        path = self.path
+        if self.format:
+            path = f"{self.path}.{self.format.lower()}"
+        return urllib.parse.urljoin(self.base_url, path)

--- a/mandible/metadata_mapper/storage/http_request.py
+++ b/mandible/metadata_mapper/storage/http_request.py
@@ -1,0 +1,46 @@
+import io
+from dataclasses import dataclass
+from typing import IO, Any, Optional, Union
+
+import requests
+
+from mandible.metadata_mapper.context import Context
+
+from .storage import Storage
+
+
+@dataclass
+class HttpRequest(Storage):
+    """A storage which returns the body of an HTTP response"""
+
+    url: str
+    method: str = "GET"
+    params: Optional[dict] = None
+    data: Optional[Union[dict, bytes]] = None
+    json: Optional[Any] = None
+    headers: Optional[dict] = None
+    cookies: Optional[dict] = None
+    timeout: Optional[Union[float, tuple[float, float]]] = None
+    allow_redirects: bool = True
+
+    def open_file(self, context: Context) -> IO[bytes]:
+        response = requests.request(
+            self.method,
+            self.url,
+            params=self.params,
+            data=self.data,
+            json=self.json,
+            headers=self.headers,
+            cookies=self.cookies,
+            timeout=self.timeout,
+            allow_redirects=self.allow_redirects,
+            stream=True,
+        )
+
+        # TODO(reweeden): Using response.content causes the entire response
+        # payload to be loaded into memory immediately. Ideally, we would
+        # optimize here by returning a file-like object that could load the
+        # response lazily. Requests does provide a response.raw file-like
+        # object, however, this doesn't preform the content decoding that you
+        # get when using response.content.
+        return io.BytesIO(response.content)

--- a/mandible/metadata_mapper/storage/storage.py
+++ b/mandible/metadata_mapper/storage/storage.py
@@ -6,7 +6,7 @@ from typing import IO, Any, Union
 
 import s3fs
 
-from .context import Context
+from mandible.metadata_mapper.context import Context
 
 
 class StorageError(Exception):

--- a/mandible/metadata_mapper/storage/storage.py
+++ b/mandible/metadata_mapper/storage/storage.py
@@ -56,6 +56,12 @@ class HttpRequest(_PlaceholderBase):
         super().__init__("requests")
 
 
+@dataclass
+class CmrQuery(_PlaceholderBase):
+    def __init__(self):
+        super().__init__("requests")
+
+
 # Define storages that don't require extra dependencies
 
 @dataclass

--- a/mandible/metadata_mapper/storage/storage.py
+++ b/mandible/metadata_mapper/storage/storage.py
@@ -31,6 +31,33 @@ class Storage(ABC):
         pass
 
 
+# Define placeholders for when extras are not installed
+
+
+@dataclass
+class _PlaceholderBase(Storage, register=False):
+    """
+    Base class for defining placeholder implementations for classes that
+    require extra dependencies to be installed
+    """
+    def __init__(self, dep: str):
+        raise Exception(
+            f"{dep} must be installed to use the {self.__class__.__name__} "
+            "format class"
+        )
+
+    def open_file(self, context: Context) -> IO[bytes]:
+        pass
+
+
+@dataclass
+class HttpRequest(_PlaceholderBase):
+    def __init__(self):
+        super().__init__("requests")
+
+
+# Define storages that don't require extra dependencies
+
 @dataclass
 class Dummy(Storage):
     """A dummy storage that returns a hardcoded byte stream.

--- a/mandible/metadata_mapper/storage/storage.py
+++ b/mandible/metadata_mapper/storage/storage.py
@@ -101,12 +101,16 @@ class FilteredStorage(Storage, register=False):
 
 @dataclass
 class LocalFile(FilteredStorage):
+    """A storage which reads from the file system"""
+
     def _open_file(self, info: dict) -> IO[bytes]:
         return open(info["path"], "rb")
 
 
 @dataclass
 class S3File(FilteredStorage):
+    """A storage which reads from an AWS S3 object"""
+
     s3fs_kwargs: dict[str, Any] = field(default_factory=dict)
 
     def _open_file(self, info: dict) -> IO[bytes]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,12 @@ lxml = { version = "^4.9.2", optional = true }
 # Numpy is pinned to a minimum version by h5py. Unpinning here means our
 # requirements will always match those of h5py.
 numpy = { version = "*", optional = true }
+requests = { version = "^2.32.3", optional = true }
 
 [tool.poetry.extras]
-all = ["h5py", "numpy", "jsonpath-ng", "lxml"]
+all = ["h5py", "numpy", "requests", "jsonpath-ng", "lxml"]
 h5 = ["h5py", "numpy"]
+http = ["requests"]
 jsonpath = ["jsonpath-ng"]
 xml = ["lxml"]
 
@@ -45,6 +47,7 @@ markers = [
     "h5: requires the 'h5' extra to be installed",
     "jsonpath: requires the 'jsonpath' extra to be installed",
     "xml: requires the 'xml' extra to be installed",
+    "http: requires the 'http' extra to be installed",
 ]
 
 [tool.isort]

--- a/tests/integration_tests/test_full_example.py
+++ b/tests/integration_tests/test_full_example.py
@@ -13,7 +13,7 @@ def sources():
             "storage": {
                 "class": "LocalFile",
                 "filters": {
-                    "name": r"example\.json",
+                    "name": "$.meta.json_file_name",
                 },
             },
             "format": {
@@ -96,6 +96,9 @@ def context(data_path):
             }
             for ext in ("json", "xml", "h5")
         ],
+        meta={
+            "json_file_name": r"example\.json",
+        },
     )
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,247 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+
+from mandible.metadata_mapper.context import (
+    Context,
+    ContextValue,
+    replace_context_values,
+)
+from mandible.metadata_mapper.exception import ContextValueError
+
+
+@dataclass
+class Dummy:
+    x: int
+    list_value: list = field(default_factory=list)
+    dict_value: dict = field(default_factory=dict)
+    recursive: Optional["Dummy"] = None
+
+
+@pytest.fixture
+def context():
+    return Context(
+        meta={
+            "foo": "foo-value",
+            "bar": "bar-value",
+            "a-number": 1,
+            "a-list": [1, 2, 3],
+            "a-dict": {"a": 1, "b": 2},
+        },
+    )
+
+
+def test_replace_context_values_noop(context):
+    # Certain objects should be passed through completely unchanged
+    for obj in (
+        1,
+        2.5,
+        "foo",
+        True,
+        None,
+        object(),
+    ):
+        assert replace_context_values(obj, context) is obj
+
+    # Nested structures will be copied, but should compare equal
+    for obj in (
+        [1, 2, 3],
+        {"a": 1, "b": 2, "c": 3},
+        Dummy(x=1),
+    ):
+        assert replace_context_values(obj, context) == obj
+
+
+def test_replace_context_values_direct(context):
+    assert replace_context_values(
+        ContextValue("$.meta.foo"),
+        context,
+    ) == "foo-value"
+    assert replace_context_values(
+        ContextValue("$.meta.bar"),
+        context,
+    ) == "bar-value"
+    assert replace_context_values(
+        ContextValue("$.meta.a-number"),
+        context,
+    ) == 1
+    assert replace_context_values(
+        ContextValue("$.meta.a-list"),
+        context,
+    ) == [1, 2, 3]
+    assert replace_context_values(
+        ContextValue("$.meta.a-dict"),
+        context,
+    ) == {"a": 1, "b": 2}
+
+
+def test_replace_context_values_nested(context):
+    # 1 level
+    assert replace_context_values(
+        {"foo": ContextValue("$.meta.foo")},
+        context,
+    ) == {"foo": "foo-value"}
+    assert replace_context_values(
+        [ContextValue("$.meta.foo")],
+        context,
+    ) == ["foo-value"]
+    assert replace_context_values(
+        Dummy(x=ContextValue("$.meta.a-number")),
+        context,
+    ) == Dummy(x=1)
+
+    # 2 levels
+    assert replace_context_values(
+        {"foo": {"bar": ContextValue("$.meta.bar")}},
+        context,
+    ) == {"foo": {"bar": "bar-value"}}
+    assert replace_context_values(
+        [[ContextValue("$.meta.foo")]],
+        context,
+    ) == [["foo-value"]]
+    assert replace_context_values(
+        Dummy(x=2, recursive=Dummy(x=ContextValue("$.meta.a-number"))),
+        context,
+    ) == Dummy(x=2, recursive=Dummy(x=1))
+
+    # Mixed types
+    assert replace_context_values(
+        {"foo": [ContextValue("$.meta.foo")]},
+        context,
+    ) == {"foo": ["foo-value"]}
+    assert replace_context_values(
+        {"foo": Dummy(x=ContextValue("$.meta.a-number"))},
+        context,
+    ) == {"foo": Dummy(x=1)}
+    assert replace_context_values(
+        [{"foo": ContextValue("$.meta.foo")}],
+        context,
+    ) == [{"foo": "foo-value"}]
+    assert replace_context_values(
+        [Dummy(x=ContextValue("$.meta.a-number"))],
+        context,
+    ) == [Dummy(x=1)]
+    assert replace_context_values(
+        Dummy(x=1, list_value=[ContextValue("$.meta.foo")]),
+        context,
+    ) == Dummy(x=1, list_value=["foo-value"])
+
+    # Large combination
+    obj = Dummy(
+        x=10,
+        list_value=[
+            [
+                [
+                    [
+                        ContextValue("$.meta.foo"),
+                        "bar",
+                    ],
+                    "baz",
+                ],
+            ],
+        ],
+        dict_value={
+            "constant": 123,
+            "nested": {
+                "list": [
+                    1,
+                    ContextValue("$.meta.foo"),
+                    ContextValue("$.meta.bar"),
+                    ["foo", ContextValue("$.meta.foo")],
+                    Dummy(x=2),
+                    Dummy(x=3, list_value=ContextValue("$.meta.a-list")),
+                ],
+                "very": {
+                    "deeply": {
+                        "nested": {
+                            "list": [
+                                1,
+                                ContextValue("$.meta.foo"),
+                                ContextValue("$.meta.bar"),
+                                ["foo", ContextValue("$.meta.foo")],
+                            ],
+                        },
+                    },
+                },
+            },
+        },
+        recursive=Dummy(
+            x=4,
+            recursive=Dummy(
+                x=5,
+                recursive=Dummy(
+                    x=6,
+                    dict_value={
+                        "foo": ContextValue("$.meta.foo"),
+                    },
+                ),
+            ),
+        ),
+    )
+
+    assert replace_context_values(obj, context) == Dummy(
+        x=10,
+        list_value=[
+            [
+                [
+                    [
+                        "foo-value",
+                        "bar",
+                    ],
+                    "baz",
+                ],
+            ],
+        ],
+        dict_value={
+            "constant": 123,
+            "nested": {
+                "list": [
+                    1,
+                    "foo-value",
+                    "bar-value",
+                    ["foo", "foo-value"],
+                    Dummy(x=2),
+                    Dummy(x=3, list_value=[1, 2, 3]),
+                ],
+                "very": {
+                    "deeply": {
+                        "nested": {
+                            "list": [
+                                1,
+                                "foo-value",
+                                "bar-value",
+                                ["foo", "foo-value"],
+                            ],
+                        },
+                    },
+                },
+            },
+        },
+        recursive=Dummy(
+            x=4,
+            recursive=Dummy(
+                x=5,
+                recursive=Dummy(
+                    x=6,
+                    dict_value={
+                        "foo": "foo-value",
+                    },
+                ),
+            ),
+        ),
+    )
+
+
+def test_replace_context_values_error(context):
+    with pytest.raises(
+        ContextValueError,
+        match=(
+            "failed to process context values: .* for path "
+            r"'\$\.meta\.does-not-exist'"
+        ),
+    ):
+        assert replace_context_values(
+            ContextValue("$.meta.does-not-exist"),
+            context,
+        )

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -1,0 +1,18 @@
+from mandible import jsonpath
+
+
+def test_get_simple():
+    data = {
+        "number": 1,
+        "foo": {
+            "bar": {
+                "baz": "string-value",
+            },
+        },
+    }
+
+    assert jsonpath.get(data, "$") == [data]
+    assert jsonpath.get(data, "number") == [1]
+    assert jsonpath.get(data, "$.number") == [1]
+    assert jsonpath.get(data, "foo.bar.baz") == ["string-value"]
+    assert jsonpath.get(data, "$.foo.bar.baz") == ["string-value"]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -7,6 +7,7 @@ from mandible.metadata_mapper.context import Context
 from mandible.metadata_mapper.storage import (
     STORAGE_REGISTRY,
     Dummy,
+    HttpRequest,
     LocalFile,
     S3File,
     Storage,
@@ -17,6 +18,7 @@ from mandible.metadata_mapper.storage import (
 def test_registry():
     assert STORAGE_REGISTRY == {
         "Dummy": Dummy,
+        "HttpRequest": HttpRequest,
         "LocalFile": LocalFile,
         "S3File": S3File,
     }

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,5 @@ extras =
     Xnone:
     Xall: all
 commands =
-    Xnone: pytest tests/ -m "not h5 and not xml and not jsonpath" {posargs}
+    Xnone: pytest tests/ -m "not h5 and not xml and not jsonpath and not http" {posargs}
     Xall: pytest tests/ {posargs}


### PR DESCRIPTION
Adds a new storage type for making HTTP requests via `requests`. There is also a convenience class with a few special parameters that are intended to make passing the CMR configuration a bit nicer.

In order to make this actually usable we also needed to add some way of injecting dynamic values into the objects returned from the source configuration. We implement that internally with a new class called `ContextValue` which is a placeholder containing a jsonpath where a value should be pulled from the `Context` object. 

The syntax we use for defining a context value in the source config is a `$` at the start of a string. This can be escaped like this `$$` in which case the string will be interpreted as a literal string starting with a single `$`. For example `$.meta.foo` will become a `ContextValue(path="$.meta.foo")`, however `$$.meta.foo` will become the string `$.meta.foo`.