### PR TITLE
PR-6309 Fix possible recursion error caused by mandible logging config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
       - uses: TrueBrain/actions-flake8@v2
         with:
           flake8_version: 6.0.0

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -22,6 +22,45 @@ def event_config():
     }
 
 
+def test_init_custom_log_record_factory_called_multiple_times(caplog):
+    for _ in range(1100):
+        init_custom_log_record_factory({})
+
+    with caplog.at_level(logging.INFO):
+        log = logging.getLogger(__name__)
+        log.info("TEST MESSAGE")
+        assert "TEST MESSAGE" in caplog.text
+
+
+def test_init_custom_log_record_factory_update(caplog):
+    init_custom_log_record_factory({})
+
+    with caplog.at_level(logging.INFO):
+        log = logging.getLogger(__name__)
+        log.info("TEST 1")
+        assert caplog.records[0].cirrus_daac_version is None
+        assert caplog.records[0].cirrus_core_version is None
+        assert caplog.records[0].cumulus_version is None
+        assert caplog.records[0].granule_name is None
+        assert caplog.records[0].workflow_execution_name is None
+
+    init_custom_log_record_factory({
+        "cumulus_meta": {
+            "cumulus_version": "v0.0.0",
+        },
+    })
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        log = logging.getLogger(__name__)
+        log.info("TEST 2")
+        assert caplog.records[0].cirrus_daac_version is None
+        assert caplog.records[0].cirrus_core_version is None
+        assert caplog.records[0].cumulus_version == "v0.0.0"
+        assert caplog.records[0].granule_name is None
+        assert caplog.records[0].workflow_execution_name is None
+
+
 def test_custom_log_record_factory(caplog, monkeypatch, event_config):
     monkeypatch.setenv("DAAC_VERSION", "TEST_DAAC")
     monkeypatch.setenv("CORE_VERSION", "TEST_CORE")


### PR DESCRIPTION
This changes our `init_custom_log_record_factory` function to only wrap the log record factory if it hasn't already wrapped it. Previously, if you called it multiple times it would create a chain of proxy calls to the previously created wrapper function, meaning if you called it more than 1000 times, you would trigger a recursion limit error.

Since this is called from our lambda handlers, it would only occur if a workflow was run more than 1000 times before the lambda container was refreshed. Waiting for a few hours and then retrying would resolve the issue since a fresh lambda container would have been created.