### PR TITLE
Add `None` as an expected template value

### DIFF
--- a/mandible/metadata_mapper/builder.py
+++ b/mandible/metadata_mapper/builder.py
@@ -244,7 +244,7 @@ def build_with_config(template: Any, config: BuildConfig) -> Template:
         return tuple(build_with_config(v, config) for v in template)
     elif isinstance(template, set):
         return set(build_with_config(v, config) for v in template)
-    elif isinstance(template, (str, int, float, bool)):
+    elif template is None or isinstance(template, (str, int, float, bool)):
         return template
 
     raise ValueError(template)

--- a/mandible/metadata_mapper/types.py
+++ b/mandible/metadata_mapper/types.py
@@ -6,13 +6,18 @@ from .context import Context
 KeyFunc = Callable[[Context], str]
 Key = Union[str, KeyFunc]
 Template = Union[
+    # Primitives
+    bool,
+    float,
+    int,
+    str,
+    # Special constants
+    None,
+    # Nested structures
     dict[str, "Template"],
     list["Template"],
-    tuple["Template", ...],
     set["Template"],
-    str,
-    int,
-    float,
-    bool,
+    tuple["Template", ...],
+    # Special types
     KeyFunc,
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.9.0"
+version = "0.9.1"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"

--- a/tests/integration_tests/test_builder.py
+++ b/tests/integration_tests/test_builder.py
@@ -28,3 +28,34 @@ def test_template(source_provider, context):
         "list": [1, 2, 3, "A", "B", "C"],
         "number": 30.5,
     }
+
+
+def test_template_default(source_provider, context):
+    mapper = MetadataMapper(
+        template=build({
+            "badkey": mapped("fixed_name_file", "badkey", default=None),
+        }),
+        source_provider=source_provider,
+    )
+
+    assert mapper.get_metadata(context) == {
+        "badkey": None,
+    }
+
+
+def test_template_default_multiple_build(source_provider, context):
+    base_template = build({
+        "badkey": mapped("fixed_name_file", "badkey", default=None),
+    })
+    mapper = MetadataMapper(
+        template=build({
+            **base_template,
+            "goodkey": mapped("fixed_name_file", "integer"),
+        }),
+        source_provider=source_provider,
+    )
+
+    assert mapper.get_metadata(context) == {
+        "badkey": None,
+        "goodkey": 10,
+    }


### PR DESCRIPTION
Templates are anything that can deserialize from Json, plus some additional special types. We missed `None` as a valid option which can deserialize from a Json `null`.