### PR TITLE
PR-6377 Add base ummg generation classes

### DIFF
--- a/mandible/umm_classes/__init__.py
+++ b/mandible/umm_classes/__init__.py
@@ -1,0 +1,25 @@
+from .base import (
+    UmmgBase,
+    UmmgCollectionReferenceEntryTitleMixin,
+    UmmgCollectionReferenceShortNameVersionMixin,
+    UmmgDataGranuleMixin,
+    UmmgDataGranuleProducerGranuleIdMixin,
+    UmmgPlatformMixin,
+    UmmgTemporalExtentRangeDateTimeMixin,
+    UmmgTemporalExtentSingleDateTimeMixin,
+)
+from .related_url_builder import DatapoolUrlBuilder, RelatedUrlBuilder, TeaUrlBuilder
+
+__all__ = (
+    "DatapoolUrlBuilder",
+    "RelatedUrlBuilder",
+    "TeaUrlBuilder",
+    "UmmgBase",
+    "UmmgCollectionReferenceEntryTitleMixin",
+    "UmmgCollectionReferenceShortNameVersionMixin",
+    "UmmgDataGranuleMixin",
+    "UmmgDataGranuleProducerGranuleIdMixin",
+    "UmmgPlatformMixin",
+    "UmmgTemporalExtentRangeDateTimeMixin",
+    "UmmgTemporalExtentSingleDateTimeMixin",
+)

--- a/mandible/umm_classes/base.py
+++ b/mandible/umm_classes/base.py
@@ -1,0 +1,365 @@
+"""Base classes for implementing UMM-G generation"""
+
+import datetime
+import logging
+from abc import ABC, abstractmethod
+from datetime import timezone
+from typing import Optional, Union, overload
+
+from .factory import (
+    data_granule,
+    identifier,
+    metadata_specification,
+    platform,
+    provider_date,
+    ummg,
+)
+from .related_url_builder import RelatedUrlBuilder
+from .types import (
+    AccessConstraints,
+    AdditionalAttribute,
+    ArchiveAndDistributionInformation,
+    CMAGranule,
+    CMAGranuleFile,
+    CollectionReference,
+    DataGranule,
+    Identifier,
+    Instrument,
+    MeasuredParameter,
+    MetadataSpecification,
+    OrbitCalculatedSpatialDomain,
+    PGEVersionClass,
+    Platform,
+    Project,
+    ProviderDate,
+    RelatedUrl,
+    SpatialExtent,
+    TemporalExtent,
+    TilingIdentificationSystem,
+    Ummg,
+)
+
+log = logging.getLogger(__name__)
+
+
+UMM_DATE_FORMAT = "%Y-%m-%d"
+UMM_DATETIME_FORMAT = f"{UMM_DATE_FORMAT}T%H:%M:%SZ"
+
+RELATED_URL_TYPE_ORDER = ["data", "browse", "metadata", "qa", "linkage"]
+
+
+class UmmgBase(ABC):
+    """Abstract base class for generating a UMM-G record.
+
+    Required UMM-G elements will either have a default implementation or have
+    associated abstract methods that need to be implemented for each workflow.
+    Mixin classes can be used to add boilerplate code for additional optional
+    fields. Mixins will similarly define abstract methods for required UMM-G
+    subelements.
+
+    Use `get_ummg()` to generate the UMM-G record.
+    """
+
+    def __init__(self, granule: CMAGranule):
+        self.now = datetime.datetime.now(timezone.utc)
+        self.granule = granule
+
+    @overload
+    def date_to_str(self, date: datetime.date) -> str:
+        ...
+
+    @overload
+    def date_to_str(self, date: None) -> None:
+        ...
+
+    def date_to_str(self, date):
+        """Serialize a datetime.date or datetime.datetime as a string using the
+        format expected by UMM-G.
+        """
+        if date is None:
+            return None
+
+        if isinstance(date, datetime.datetime):
+            return date.strftime(self.get_umm_date_time_format())
+        else:
+            return date.strftime(self.get_umm_date_format())
+
+    def get_provider_time(self) -> datetime.datetime:
+        return self.now
+
+    def get_related_urls_files(self) -> list[CMAGranuleFile]:
+        return sorted(
+            self.get_granule_files(),
+            key=self.related_urls_files_sort_key,
+        )
+
+    def get_related_url_builder(
+        self,
+        file: CMAGranuleFile,
+    ) -> Optional[RelatedUrlBuilder]:
+        return None
+
+    def get_related_url_type_order(self) -> list[str]:
+        return RELATED_URL_TYPE_ORDER
+
+    def get_umm_date_format(self) -> str:
+        return UMM_DATE_FORMAT
+
+    def get_umm_date_time_format(self) -> str:
+        return UMM_DATETIME_FORMAT
+
+    def related_urls_files_sort_key(self, file: CMAGranuleFile) -> tuple:
+        type_order = self.get_related_url_type_order()
+        try:
+            type_ordinal = type_order.index(file.get("type"))
+        except ValueError:
+            type_ordinal = len(type_order)
+
+        return (
+            type_ordinal,
+            file.get("fileName"),
+        )
+
+    #
+    # UMM-G elements
+    #
+
+    def get_access_constraints(self) -> Optional[AccessConstraints]:
+        return None
+
+    def get_additional_attributes(self) -> list[AdditionalAttribute]:
+        return []
+
+    def get_cloud_cover(self) -> Optional[Union[float, int]]:
+        return None
+
+    @abstractmethod
+    def get_collection_reference(self) -> CollectionReference:
+        pass
+
+    def get_data_granule(self) -> Optional[DataGranule]:
+        return None
+
+    def get_granule_files(self) -> list[CMAGranuleFile]:
+        return self.granule["files"]
+
+    def get_granule_ur(self) -> str:
+        return self.granule["granuleId"]
+
+    def get_grid_mapping_names(self) -> list[str]:
+        return []
+
+    def get_input_granules(self) -> list[str]:
+        return []
+
+    def get_measured_parameters(self) -> list[MeasuredParameter]:
+        return []
+
+    def get_metadata_specification(self) -> MetadataSpecification:
+        return metadata_specification("1.6.5")
+
+    def get_native_projection_names(self) -> list[str]:
+        return []
+
+    def get_orbit_calculated_spatial_domains(
+        self,
+    ) -> list[OrbitCalculatedSpatialDomain]:
+        return []
+
+    def get_pge_version_class(self) -> Optional[PGEVersionClass]:
+        return None
+
+    def get_platforms(self) -> list[Platform]:
+        return []
+
+    def get_projects(self) -> list[Project]:
+        return []
+
+    def get_provider_dates(self) -> list[ProviderDate]:
+        return [
+            provider_date("Insert", self.date_to_str(self.get_provider_time())),
+            provider_date("Update", self.date_to_str(self.get_provider_time())),
+        ]
+
+    def get_related_urls(self) -> list[RelatedUrl]:
+        return [
+            url
+            for file in self.get_related_urls_files()
+            if (builder := self.get_related_url_builder(file))
+            for url in builder.get_related_urls()
+        ]
+
+    def get_spatial_extent(self) -> Optional[SpatialExtent]:
+        return None
+
+    def get_temporal_extent(self) -> Optional[TemporalExtent]:
+        return None
+
+    def get_tiling_identification_system(
+        self,
+    ) -> Optional[TilingIdentificationSystem]:
+        return None
+
+    def get_ummg(self) -> Ummg:
+        return ummg(
+            access_constraints=self.get_access_constraints(),
+            additional_attributes=sorted(
+                self.get_additional_attributes(),
+                key=lambda attr: attr["Name"],
+            ) or None,
+            cloud_cover=self.get_cloud_cover(),
+            collection_reference=self.get_collection_reference(),
+            data_granule=self.get_data_granule(),
+            granule_ur=self.get_granule_ur(),
+            grid_mapping_names=self.get_grid_mapping_names() or None,
+            input_granules=self.get_input_granules() or None,
+            measured_parameters=self.get_measured_parameters() or None,
+            metadata_specification=self.get_metadata_specification(),
+            native_projection_names=self.get_native_projection_names() or None,
+            orbit_calculated_spatial_domains=(
+                self.get_orbit_calculated_spatial_domains() or None
+            ),
+            pge_version_class=self.get_pge_version_class(),
+            platforms=self.get_platforms() or None,
+            projects=self.get_projects() or None,
+            provider_dates=self.get_provider_dates(),
+            related_urls=self.get_related_urls() or None,
+            spatial_extent=self.get_spatial_extent(),
+            temporal_extent=self.get_temporal_extent(),
+            tiling_identification_system=self.get_tiling_identification_system(),
+        )
+
+
+class UmmgCollectionReferenceEntryTitleMixin(UmmgBase):
+    @abstractmethod
+    def get_cmr_entry_title(self) -> str:
+        pass
+
+    def get_collection_reference(self) -> CollectionReference:
+        return {
+            "EntryTitle": self.get_cmr_entry_title(),
+        }
+
+
+class UmmgCollectionReferenceShortNameVersionMixin(UmmgBase):
+    @abstractmethod
+    def get_cmr_short_name(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_cmr_version(self) -> str:
+        pass
+
+    def get_collection_reference(self) -> CollectionReference:
+        return {
+            "ShortName": self.get_cmr_short_name(),
+            "Version": self.get_cmr_version(),
+        }
+
+
+class UmmgDataGranuleMixin(UmmgBase):
+    """Adds a DataGranule attribute to the UMM-G"""
+
+    def get_archive_and_distribution_information(
+        self,
+    ) -> list[ArchiveAndDistributionInformation]:
+        return []
+
+    def get_data_granule(self) -> DataGranule:
+        return data_granule(
+            archive_and_distribution_information=(
+                self.get_archive_and_distribution_information() or None
+            ),
+            day_night_flag=self.get_day_night_flag(),
+            identifiers=self.get_identifiers() or None,
+            production_date_time=self.date_to_str(
+                self.get_production_date_time(),
+            ),
+            reprocessing_actual=self.get_reprocessing_actual(),
+            reprocessing_planned=self.get_reprocessing_planned(),
+        )
+
+    def get_day_night_flag(self) -> str:
+        return "Unspecified"
+
+    def get_identifiers(self) -> list[Identifier]:
+        return []
+
+    @abstractmethod
+    def get_production_date_time(self) -> datetime.datetime:
+        pass
+
+    def get_reprocessing_actual(self) -> Optional[str]:
+        return None
+
+    def get_reprocessing_planned(self) -> Optional[str]:
+        return None
+
+
+class UmmgDataGranuleProducerGranuleIdMixin(UmmgDataGranuleMixin):
+    """Includes the GranuleUR as the ProducerGranuleId in DataGranule.Identifiers"""
+
+    def get_identifiers(self) -> list[Identifier]:
+        return super().get_identifiers() + [
+            identifier("ProducerGranuleId", self.get_producer_granule_id()),
+        ]
+
+    @abstractmethod
+    def get_producer_granule_id(self) -> str:
+        pass
+
+
+class UmmgPlatformMixin(UmmgBase):
+    """Adds a single Platform to the UMM-G"""
+
+    def get_instruments(self) -> list[Instrument]:
+        return []
+
+    @abstractmethod
+    def get_platform_name(self) -> str:
+        pass
+
+    def get_platforms(self) -> list[Platform]:
+        return super().get_platforms() + [
+            platform(
+                short_name=self.get_platform_name(),
+                instruments=self.get_instruments() or None,
+            ),
+        ]
+
+
+class UmmgTemporalExtentRangeDateTimeMixin(UmmgBase):
+    """Adds a TemporalExtent with RangeDateTime to the UMM-G"""
+
+    @abstractmethod
+    def get_beginning_date_time(self) -> datetime.datetime:
+        pass
+
+    @abstractmethod
+    def get_ending_date_time(self) -> datetime.datetime:
+        pass
+
+    def get_temporal_extent(self) -> TemporalExtent:
+        return {
+            "RangeDateTime": {
+                "BeginningDateTime": self.date_to_str(
+                    self.get_beginning_date_time(),
+                ),
+                "EndingDateTime": self.date_to_str(
+                    self.get_ending_date_time(),
+                ),
+            },
+        }
+
+
+class UmmgTemporalExtentSingleDateTimeMixin(UmmgBase):
+    """Adds a TemporalExtent with SingleDateTime to the UMM-G"""
+
+    @abstractmethod
+    def get_single_date_time(self) -> datetime.datetime:
+        pass
+
+    def get_temporal_extent(self) -> TemporalExtent:
+        return {
+            "SingleDateTime": self.date_to_str(self.get_single_date_time()),
+        }

--- a/mandible/umm_classes/factory.py
+++ b/mandible/umm_classes/factory.py
@@ -1,0 +1,200 @@
+"""Factory functions for creating small pieces of UMM"""
+
+from typing import Optional, Union
+
+from .types import (
+    AccessConstraints,
+    AdditionalAttribute,
+    ArchiveAndDistributionInformation,
+    CollectionReference,
+    DataGranule,
+    Identifier,
+    Instrument,
+    MeasuredParameter,
+    MetadataSpecification,
+    OrbitCalculatedSpatialDomain,
+    PGEVersionClass,
+    Platform,
+    Project,
+    ProviderDate,
+    RelatedUrl,
+    SpatialExtent,
+    TemporalExtent,
+    TilingIdentificationSystem,
+    Ummg,
+)
+
+
+def additional_attribute(name: str, *value: str) -> AdditionalAttribute:
+    return {
+        "Name": name,
+        "Values": list(value),
+    }
+
+
+def data_granule(
+    day_night_flag: str,
+    production_date_time: str,
+    archive_and_distribution_information: Optional[list[ArchiveAndDistributionInformation]] = None,
+    reprocessing_planned: Optional[str] = None,
+    reprocessing_actual: Optional[str] = None,
+    identifiers: Optional[list[Identifier]] = None,
+) -> DataGranule:
+    obj: DataGranule = {
+        "DayNightFlag": day_night_flag,
+        "ProductionDateTime": production_date_time,
+    }
+    if archive_and_distribution_information is not None:
+        obj["ArchiveAndDistributionInformation"] = archive_and_distribution_information
+    if reprocessing_planned is not None:
+        obj["ReprocessingPlanned"] = reprocessing_planned
+    if reprocessing_actual is not None:
+        obj["ReprocessingActual"] = reprocessing_actual
+    if identifiers is not None:
+        obj["Identifiers"] = identifiers
+
+    return obj
+
+
+def identifier(
+    type: str,
+    identifier: str,
+    name: Optional[str] = None,
+) -> Identifier:
+    obj: Identifier = {
+        "IdentifierType": type,
+        "Identifier": identifier,
+    }
+    if name is not None:
+        obj["IdentifierName"] = name
+
+    return obj
+
+
+def metadata_specification(version: str) -> MetadataSpecification:
+    return {
+        "Name": "UMM-G",
+        "URL": f"https://cdn.earthdata.nasa.gov/umm/granule/v{version}",
+        "Version": version,
+    }
+
+
+def pge_version_class(name: str, version: str) -> PGEVersionClass:
+    return {
+        "PGEName": name,
+        "PGEVersion": version,
+    }
+
+
+def platform(
+    short_name: str,
+    instruments: Optional[list[Instrument]] = None,
+) -> Platform:
+    obj: Platform = {
+        "ShortName": short_name,
+    }
+    if instruments is not None:
+        obj["Instruments"] = instruments
+
+    return obj
+
+
+def provider_date(type: str, date: str) -> ProviderDate:
+    return {
+        "Type": type,
+        "Date": date,
+    }
+
+
+def related_url(
+    url: str,
+    type: str,
+    subtype: Optional[str] = None,
+    description: Optional[str] = None,
+    format: Optional[str] = None,
+    mime_type: Optional[str] = None,
+    size: Optional[Union[float, int]] = None,
+    size_unit: Optional[str] = None,
+) -> RelatedUrl:
+    obj: RelatedUrl = {
+        "URL": url,
+        "Type": type,
+    }
+    if subtype is not None:
+        obj["Subtype"] = subtype
+    if description is not None:
+        obj["Description"] = description
+    if format is not None:
+        obj["Format"] = format
+    if mime_type is not None:
+        obj["MimeType"] = mime_type
+    if size is not None:
+        obj["Size"] = size
+    if size_unit is not None:
+        obj["SizeUnit"] = size_unit
+
+    return obj
+
+
+def ummg(
+    granule_ur: str,
+    provider_dates: list[ProviderDate],
+    collection_reference: CollectionReference,
+    metadata_specification: MetadataSpecification,
+    access_constraints: Optional[AccessConstraints] = None,
+    data_granule: Optional[DataGranule] = None,
+    pge_version_class: Optional[PGEVersionClass] = None,
+    temporal_extent: Optional[TemporalExtent] = None,
+    spatial_extent: Optional[SpatialExtent] = None,
+    orbit_calculated_spatial_domains: Optional[list[OrbitCalculatedSpatialDomain]] = None,
+    measured_parameters: Optional[list[MeasuredParameter]] = None,
+    platforms: Optional[list[Platform]] = None,
+    projects: Optional[list[Project]] = None,
+    additional_attributes: Optional[list[AdditionalAttribute]] = None,
+    input_granules: Optional[list[str]] = None,
+    tiling_identification_system: Optional[TilingIdentificationSystem] = None,
+    cloud_cover: Optional[Union[float, int]] = None,
+    related_urls: Optional[list[RelatedUrl]] = None,
+    native_projection_names: Optional[list[str]] = None,
+    grid_mapping_names: Optional[list[str]] = None,
+) -> Ummg:
+    obj: Ummg = {
+        "CollectionReference": collection_reference,
+        "GranuleUR": granule_ur,
+        "MetadataSpecification": metadata_specification,
+        "ProviderDates": provider_dates,
+    }
+    if access_constraints is not None:
+        obj["AccessConstraints"] = access_constraints
+    if data_granule is not None:
+        obj["DataGranule"] = data_granule
+    if pge_version_class is not None:
+        obj["PGEVersionClass"] = pge_version_class
+    if temporal_extent is not None:
+        obj["TemporalExtent"] = temporal_extent
+    if spatial_extent is not None:
+        obj["SpatialExtent"] = spatial_extent
+    if orbit_calculated_spatial_domains is not None:
+        obj["OrbitCalculatedSpatialDomains"] = orbit_calculated_spatial_domains
+    if measured_parameters is not None:
+        obj["MeasuredParameters"] = measured_parameters
+    if platforms is not None:
+        obj["Platforms"] = platforms
+    if projects is not None:
+        obj["Projects"] = projects
+    if additional_attributes is not None:
+        obj["AdditionalAttributes"] = additional_attributes
+    if input_granules is not None:
+        obj["InputGranules"] = input_granules
+    if tiling_identification_system is not None:
+        obj["TilingIdentificationSystem"] = tiling_identification_system
+    if cloud_cover is not None:
+        obj["CloudCover"] = cloud_cover
+    if related_urls is not None:
+        obj["RelatedUrls"] = related_urls
+    if native_projection_names is not None:
+        obj["NativeProjectionNames"] = native_projection_names
+    if grid_mapping_names is not None:
+        obj["GridMappingNames"] = grid_mapping_names
+
+    return obj

--- a/mandible/umm_classes/related_url_builder.py
+++ b/mandible/umm_classes/related_url_builder.py
@@ -1,0 +1,159 @@
+"""Classes for generating RelatedUrl links"""
+
+import urllib.parse
+from abc import ABC, abstractmethod
+from typing import Optional, Union
+
+from .factory import related_url
+from .types import CMAGranuleFile, RelatedUrl
+
+
+class RelatedUrlBuilder(ABC):
+    RELATED_URL_HTTP_TYPE_MAP = {
+        "browse": "GET RELATED VISUALIZATION",
+        "data": "GET DATA",
+        "linkage": "VIEW RELATED INFORMATION",
+        "metadata": "EXTENDED METADATA",
+        "qa": "VIEW RELATED INFORMATION",
+    }
+    RELATED_URL_S3_TYPE_MAP = {
+        **RELATED_URL_HTTP_TYPE_MAP,
+        "data": "GET DATA VIA DIRECT ACCESS",
+    }
+
+    def __init__(self, file: CMAGranuleFile, include_s3_uri: bool = True):
+        self.file = file
+        self.include_s3_uri = include_s3_uri
+
+    def get_http_description(self) -> Optional[str]:
+        return f'Download {self.file["fileName"]}'
+
+    def get_http_format(self) -> Optional[str]:
+        return None
+
+    def get_http_mime_type(self) -> Optional[str]:
+        return None
+
+    def get_http_size(self) -> Optional[Union[float, int]]:
+        return None
+
+    def get_http_size_unit(self) -> Optional[str]:
+        return None
+
+    def get_http_subtype(self) -> Optional[str]:
+        return None
+
+    def get_http_type(self) -> str:
+        file_type = self.file.get("type", "data")
+        return self.RELATED_URL_HTTP_TYPE_MAP[file_type]
+
+    @abstractmethod
+    def get_http_url(self) -> str:
+        pass
+
+    def get_related_urls(self) -> list[RelatedUrl]:
+        http_url = self.get_related_url_http()
+
+        if self.include_s3_uri:
+            # It seems that Earthdata Search will blindly use the first browse
+            # image RelatedUrl it finds so we need to put the HTTP url first.
+            return [
+                http_url,
+                self.get_related_url_s3(),
+            ]
+
+        return [http_url]
+
+    def get_related_url_http(self) -> RelatedUrl:
+        return related_url(
+            url=self.get_http_url(),
+            type=self.get_http_type(),
+            subtype=self.get_http_subtype(),
+            description=self.get_http_description(),
+            format=self.get_http_format(),
+            mime_type=self.get_http_mime_type(),
+            size=self.get_http_size(),
+            size_unit=self.get_http_size_unit(),
+        )
+
+    def get_related_url_s3(self) -> RelatedUrl:
+        return related_url(
+            url=self.get_s3_url(),
+            type=self.get_s3_type(),
+            subtype=self.get_s3_subtype(),
+            description=self.get_s3_description(),
+            format=self.get_s3_format(),
+            mime_type=self.get_s3_mime_type(),
+            size=self.get_s3_size(),
+            size_unit=self.get_s3_size_unit(),
+        )
+
+    def get_s3_description(self) -> Optional[str]:
+        return (
+            "This link provides direct download access via S3 to "
+            f'{self.file["fileName"]}'
+        )
+
+    def get_s3_format(self) -> Optional[str]:
+        return None
+
+    def get_s3_mime_type(self) -> Optional[str]:
+        return None
+
+    def get_s3_size(self) -> Optional[Union[float, int]]:
+        return None
+
+    def get_s3_size_unit(self) -> Optional[str]:
+        return None
+
+    def get_s3_subtype(self) -> Optional[str]:
+        return None
+
+    def get_s3_type(self) -> str:
+        file_type = self.file.get("type", "data")
+        return self.RELATED_URL_S3_TYPE_MAP[file_type]
+
+    def get_s3_url(self) -> str:
+        return f"s3://{self.file['bucket']}/{self.file['key']}"
+
+
+class DatapoolUrlBuilder(RelatedUrlBuilder):
+    def __init__(
+        self,
+        file: CMAGranuleFile,
+        download_host: str,
+        processing_type: str,
+        mission: str,
+        include_s3_uri: bool = True,
+    ):
+        super().__init__(file, include_s3_uri)
+
+        self.download_host = download_host
+        self.processing_type = processing_type
+        self.mission = mission
+
+    def get_http_url(self) -> str:
+        return (
+            f"https://{self.download_host}/{self.processing_type}"
+            f'/{self.mission}/{self.file["fileName"]}'
+        )
+
+
+class TeaUrlBuilder(RelatedUrlBuilder):
+    def __init__(
+        self,
+        file: CMAGranuleFile,
+        download_url: str,
+        path_prefix: str,
+        include_s3_uri: bool = True,
+    ):
+        super().__init__(file, include_s3_uri)
+
+        self.download_url = download_url
+        self.path_prefix = path_prefix
+
+    def get_http_url(self) -> str:
+        return urllib.parse.urljoin(
+            self.download_url,
+            f'{self.path_prefix}/{self.file["key"]}',
+        )

--- a/mandible/umm_classes/types.py
+++ b/mandible/umm_classes/types.py
@@ -1,0 +1,400 @@
+"""UMM-G and Cumulus type definitions used by UmmgBase"""
+
+from typing import Any, Union
+
+from typing_extensions import NotRequired, TypedDict
+
+# JSONSchema definitions are available here:
+# https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule
+
+
+class AccessConstraints(TypedDict):
+    """AccessConstraints type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#195
+    """
+    Description: NotRequired[str]
+    Value: Union[float, int]
+
+
+class AdditionalAttribute(TypedDict):
+    """AdditionalAttribute type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#1057
+    """
+    Name: str
+    Values: list[str]
+
+
+class ArchiveAndDistributionInformationFilePackageType(TypedDict):
+    """ArchiveAndDistributionInformation type definition for FilePackageType.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#263
+    """
+    Name: str
+    SizeInBytes: NotRequired[int]
+    Size: NotRequired[Union[float, int]]
+    SizeUnit: NotRequired[str]
+    Format: NotRequired[str]
+    MimeType: NotRequired[str]
+    Checksum: NotRequired["Checksum"]
+    Files: NotRequired[list["ArchiveAndDistributionInformationFileType"]]
+
+
+class ArchiveAndDistributionInformationFileType(TypedDict):
+    """ArchiveAndDistributionInformation type definition for FileType.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#309
+    """
+    Name: str
+    SizeInBytes: NotRequired[int]
+    Size: NotRequired[Union[float, int]]
+    SizeUnit: NotRequired[str]
+    Format: NotRequired[str]
+    FormatType: NotRequired[str]
+    MimeType: NotRequired[str]
+    Checksum: NotRequired["Checksum"]
+
+
+ArchiveAndDistributionInformation = Union[
+    ArchiveAndDistributionInformationFileType,
+    ArchiveAndDistributionInformationFilePackageType,
+]
+
+
+class BoundingRectangle(TypedDict):
+    """BoundingRectangle type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#591
+    """
+    WestBoundingCoordinate: Union[float, int]
+    NorthBoundingCoordinate: Union[float, int]
+    EastBoundingCoordinate: Union[float, int]
+    SouthBoundingCoordinate: Union[float, int]
+
+
+class Boundary(TypedDict):
+    """Boundary type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#625
+    """
+    Points: list["Point"]
+
+
+class Characteristic(TypedDict):
+    """Characteristic type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#1008
+    """
+    Name: str
+    Value: str
+
+
+class Checksum(TypedDict):
+    """CollectionReference type definition with ShortName and Version.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#1159
+    """
+    Value: str
+    Algorithm: str
+
+
+class CollectionReferenceShortNameVersion(TypedDict):
+    """CollectionReference type definition with ShortName and Version.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#166
+    """
+    ShortName: str
+    Version: str
+
+
+class CollectionReferenceEntryTitle(TypedDict):
+    """CollectionReference type definition with EntryTitle.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#184
+    """
+    EntryTitle: str
+
+
+CollectionReference = Union[
+    CollectionReferenceEntryTitle,
+    CollectionReferenceShortNameVersion,
+]
+
+
+class DataGranule(TypedDict):
+    """DataGranule type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#213
+    """
+    ArchiveAndDistributionInformation: NotRequired[list[ArchiveAndDistributionInformation]]
+    ReprocessingPlanned: NotRequired[str]
+    ReprocessingActual: NotRequired[str]
+    DayNightFlag: str
+    ProductionDateTime: str
+    Identifiers: NotRequired[list["Identifier"]]
+
+
+class ExclusiveZone(TypedDict):
+    """ExclusiveZone type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#640
+    """
+    Boundaries: list[Boundary]
+
+
+class Geometry(TypedDict):
+    """Geometry type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#525
+    """
+    Points: NotRequired[list["Point"]]
+    BoundingRectangles: NotRequired[list[BoundingRectangle]]
+    GPolygons: NotRequired[list["GPolygon"]]
+    Lines: NotRequired[list["Line"]]
+
+
+class GPolygon(TypedDict):
+    """GPolygon type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#611
+    """
+    Boundary: Boundary
+    ExclusiveZone: NotRequired[ExclusiveZone]
+
+
+class HorizontalSpatialDomain(TypedDict):
+    """HorizontalSpatialDomain type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#497
+    """
+    # TODO(reweeden): Implement
+    ZoneIdentifier: NotRequired[dict[str, Any]]
+    Geometry: NotRequired[Geometry]
+    # TODO(reweeden): Implement
+    Orbit: NotRequired[dict[str, Any]]
+    # TODO(reweeden): Implement
+    Track: NotRequired[dict[str, Any]]
+
+
+class Identifier(TypedDict):
+    """Identifier type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#353
+    """
+    Identifier: str
+    IdentifierType: str
+    IdentifierName: NotRequired[str]
+
+
+class Instrument(TypedDict):
+    """Instrument type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#968
+    """
+    ShortName: str
+    Characteristics: NotRequired[list[Characteristic]]
+    ComposedOf: NotRequired[list["Instrument"]]
+    OperationalModes: NotRequired[list[str]]
+
+
+class Line(TypedDict):
+    """Line type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#655
+    """
+    Points: list["Point"]
+
+
+class MeasuredParameter(TypedDict):
+    """MeasuredParameter type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#840
+    """
+    ParameterName: str
+    # TODO(reweeden): Implement
+    QAStats: NotRequired[dict[str, Any]]
+    # TODO(reweeden): Implement
+    QAFlags: NotRequired[dict[str, Any]]
+
+
+class MetadataSpecification(TypedDict):
+    """MetadataSpecification type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#1285
+    """
+    URL: str
+    Name: str
+    Version: str
+
+
+class OrbitCalculatedSpatialDomain(TypedDict):
+    """OrbitCalculatedSpatialDomain type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#786
+    """
+    OrbitalModelName: NotRequired[str]
+    OrbitNumber: NotRequired[int]
+    BeginOrbitNumber: NotRequired[int]
+    EndOrbitNumber: NotRequired[int]
+    EquatorCrossingLongitude: NotRequired[Union[float, int]]
+    EquatorCrossingDateTime: NotRequired[str]
+
+
+class PGEVersionClass(TypedDict):
+    """PGEVersionClass type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#403
+    """
+    PGEName: NotRequired[str]
+    PGEVersion: str
+
+
+class Platform(TypedDict):
+    """Platform type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#949
+    """
+    ShortName: str
+    Instruments: NotRequired[list[Instrument]]
+
+
+class Point(TypedDict):
+    """GPolygon type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#611
+    """
+    Longitude: Union[float, int]
+    Latitude: Union[float, int]
+
+
+class Project(TypedDict):
+    """Project type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#1028
+    """
+    ShortName: str
+    Campaigns: NotRequired[list[str]]
+
+
+class ProviderDate(TypedDict):
+    """ProviderDate type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#144
+    """
+    Date: str
+    Type: str
+
+
+class RangeDateTime(TypedDict):
+    """RangeDateTime type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#447
+    """
+    BeginningDateTime: str
+    EndingDateTime: NotRequired[str]
+
+
+class RelatedUrl(TypedDict):
+    """RelatedUrl type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#1112
+    """
+    URL: str
+    Type: str
+    Subtype: NotRequired[str]
+    Description: NotRequired[str]
+    Format: NotRequired[str]
+    MimeType: NotRequired[str]
+    Size: NotRequired[Union[float, int]]
+    SizeUnit: NotRequired[str]
+
+
+class SpatialExtent(TypedDict):
+    """SpatialExtent type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#465
+    """
+    # TODO(reweeden): Implement
+    GranuleLocalities: NotRequired[list[dict[str, Any]]]
+    HorizontalSpatialDomain: NotRequired["HorizontalSpatialDomain"]
+    # TODO(reweeden): Implement
+    VerticalSpatialDomains: NotRequired[list[dict[str, Any]]]
+
+
+class TemporalExtentRangeDateTime(TypedDict):
+    """TemporalExtent type definition with RangeDateTime.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#428
+    """
+    RangeDateTime: RangeDateTime
+
+
+class TemporalExtentSingleDateTime(TypedDict):
+    """TemporalExtent type definition with SingleDateTime.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#437
+    """
+    SingleDateTime: str
+
+
+TemporalExtent = Union[
+    TemporalExtentRangeDateTime,
+    TemporalExtentSingleDateTime,
+]
+
+
+class TilingIdentificationSystem(TypedDict):
+    """TilingIdentificationSystem type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#1081
+    """
+    TilingIdentificationSystemName: str
+    # TODO(reweeden): Implement
+    Coordinate1: dict[str, Any]
+    # TODO(reweeden): Implement
+    Coordinate2: dict[str, Any]
+
+
+class Ummg(TypedDict):
+    """UMM-G type definition.
+
+    https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#7
+    """
+    GranuleUR: str
+    ProviderDates: list[ProviderDate]
+    CollectionReference: CollectionReference
+    AccessConstraints: NotRequired[AccessConstraints]
+    DataGranule: NotRequired[DataGranule]
+    PGEVersionClass: NotRequired[PGEVersionClass]
+    TemporalExtent: NotRequired[TemporalExtent]
+    SpatialExtent: NotRequired[SpatialExtent]
+    OrbitCalculatedSpatialDomains: NotRequired[list[OrbitCalculatedSpatialDomain]]
+    MeasuredParameters: NotRequired[list[MeasuredParameter]]
+    Platforms: NotRequired[list[Platform]]
+    Projects: NotRequired[list[Project]]
+    AdditionalAttributes: NotRequired[list[AdditionalAttribute]]
+    InputGranules: NotRequired[list[str]]
+    TilingIdentificationSystem: NotRequired[TilingIdentificationSystem]
+    CloudCover: NotRequired[Union[float, int]]
+    RelatedUrls: NotRequired[list[RelatedUrl]]
+    NativeProjectionNames: NotRequired[list[str]]
+    GridMappingNames: NotRequired[list[str]]
+    MetadataSpecification: MetadataSpecification
+
+# Other TypedDict definitions
+
+
+class CMAGranule(TypedDict, total=False):
+    granuleId: str
+    files: list["CMAGranuleFile"]
+
+
+class CMAGranuleFile(TypedDict, total=False):
+    bucket: str
+    checksum: NotRequired[str]
+    checksumType: NotRequired[str]
+    fileName: str
+    key: str
+    size: NotRequired[int]
+    type: NotRequired[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.9.1"
+version = "0.9.2"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"
@@ -16,6 +16,7 @@ python = ">=3.9"
 
 # Required
 s3fs = ">=0.4.2"
+typing-extensions = "^4.12.2"
 
 # Optional
 h5py = { version = "^3.6.0", optional = true }

--- a/tests/integration_tests/test_umm_classes.py
+++ b/tests/integration_tests/test_umm_classes.py
@@ -1,0 +1,486 @@
+import datetime
+from typing import Optional
+
+import pytest
+
+from mandible.umm_classes import (
+    RelatedUrlBuilder,
+    TeaUrlBuilder,
+    UmmgBase,
+    UmmgCollectionReferenceShortNameVersionMixin,
+    UmmgDataGranuleProducerGranuleIdMixin,
+    UmmgPlatformMixin,
+    UmmgTemporalExtentRangeDateTimeMixin,
+)
+from mandible.umm_classes.factory import (
+    additional_attribute,
+    identifier,
+    pge_version_class,
+)
+from mandible.umm_classes.types import (
+    AccessConstraints,
+    AdditionalAttribute,
+    ArchiveAndDistributionInformation,
+    CMAGranule,
+    CMAGranuleFile,
+    Identifier,
+    Instrument,
+    MeasuredParameter,
+    OrbitCalculatedSpatialDomain,
+    PGEVersionClass,
+    Project,
+    SpatialExtent,
+    TilingIdentificationSystem,
+)
+
+
+class LocalUmmgBase(UmmgCollectionReferenceShortNameVersionMixin, UmmgBase):
+    def get_cmr_short_name(self) -> str:
+        return "TEST_CMR_SHORT_NAME"
+
+    def get_cmr_version(self) -> str:
+        return "1"
+
+
+@pytest.fixture
+def granule() -> CMAGranule:
+    return {
+        "granuleId": "TEST_GRANULE_ID",
+        "files": [
+            {
+                "fileName": "test_file.txt",
+                "bucket": "test_bucket",
+                "key": "test_prefix/test_file.txt",
+                "type": "data",
+            },
+        ],
+    }
+
+
+def test_get_ummg_basic(granule):
+    ummg_obj = LocalUmmgBase(granule)
+    ummg_obj.now = datetime.datetime(2025, 1, 1)
+
+    ummg_dict = ummg_obj.get_ummg()
+
+    assert ummg_dict == {
+        "CollectionReference": {
+            "ShortName": "TEST_CMR_SHORT_NAME",
+            "Version": "1",
+        },
+        "GranuleUR": "TEST_GRANULE_ID",
+        "MetadataSpecification": {
+            "Name": "UMM-G",
+            "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.6.5",
+            "Version": "1.6.5",
+        },
+        "ProviderDates": [
+            {"Date": "2025-01-01T00:00:00Z", "Type": "Insert"},
+            {"Date": "2025-01-01T00:00:00Z", "Type": "Update"},
+        ],
+    }
+
+
+def test_get_ummg_full(granule):
+    class FullUmmg(
+        UmmgDataGranuleProducerGranuleIdMixin,
+        UmmgPlatformMixin,
+        UmmgTemporalExtentRangeDateTimeMixin,
+        LocalUmmgBase,
+    ):
+        def get_access_constraints(self) -> AccessConstraints:
+            return {
+                "Value": 1,
+            }
+
+        def get_additional_attributes(self) -> list[AdditionalAttribute]:
+            # Return the attributes out of order so they get sorted
+            return super().get_additional_attributes() + [
+                additional_attribute("TEST_ADDITIONAL_ATTRIBUTE_2", "TEST_VALUE_2"),
+                additional_attribute("TEST_ADDITIONAL_ATTRIBUTE", "TEST_VALUE"),
+            ]
+
+        def get_archive_and_distribution_information(
+            self,
+        ) -> list[ArchiveAndDistributionInformation]:
+            return super().get_archive_and_distribution_information() + [
+                {
+                    "Name": "distribution.zip",
+                    "Size": 0.5,
+                    "SizeUnit": "MB",
+                    "Format": "Zip",
+                    "MimeType": "application/zip",
+                    "Checksum": {
+                        "Value": "00000000000000000000000000000000",
+                        "Algorithm": "MD5",
+                    },
+                    "Files": [
+                        {
+                            "Name": file["fileName"],
+                            "SizeInBytes": 12345,
+                            "Format": "Text",
+                            "FormatType": "NA",
+                            "Checksum": {
+                                "Value": "00000000000000000000000000000000",
+                                "Algorithm": "MD5",
+                            },
+                        }
+                        for file in self.granule["files"]
+                    ],
+                },
+            ]
+
+        def get_beginning_date_time(self) -> datetime.datetime:
+            return datetime.datetime(2024, 1, 1)
+
+        def get_cloud_cover(self) -> int:
+            return 0
+
+        def get_ending_date_time(self) -> datetime.datetime:
+            return datetime.datetime(2024, 1, 2)
+
+        def get_grid_mapping_names(self) -> list[str]:
+            return super().get_grid_mapping_names() + [
+                "GRID_MAPPING_NAME_1",
+                "GRID_MAPPING_NAME_2",
+            ]
+
+        def get_identifiers(self) -> list[Identifier]:
+            return super().get_identifiers() + [
+                identifier("Other", "TEST_SAS_VERSION", "SASVersionId"),
+            ]
+
+        def get_input_granules(self) -> list[str]:
+            return super().get_input_granules() + [
+                "INPUT_GRANULE_1",
+                "INPUT_GRANULE_2",
+            ]
+
+        def get_instruments(self) -> list[Instrument]:
+            return super().get_instruments() + [
+                {
+                    "ShortName": "INSTRUMENT_1",
+                    "Characteristics": [
+                        {
+                            "Name": "CHARACTERISTIC_1",
+                            "Value": "VALUE_1",
+                        },
+                    ],
+                    "ComposedOf": [
+                        {"ShortName": "INSTRUMENT_1-A"},
+                        {"ShortName": "INSTRUMENT_1-B"},
+                    ],
+                    "OperationalModes": ["OP1", "OP2"],
+                },
+            ]
+
+        def get_measured_parameters(self) -> list[MeasuredParameter]:
+            return super().get_measured_parameters() + [
+                {
+                    "ParameterName": "PARAM_1",
+                },
+                {
+                    "ParameterName": "PARAM_2",
+                    "QAStats": {},
+                    "QAFlags": {},
+                },
+            ]
+
+        def get_native_projection_names(self) -> list[str]:
+            return super().get_native_projection_names() + [
+                "NATIVE_PROJECTION_NAME_1",
+                "NATIVE_PROJECTION_NAME_2",
+            ]
+
+        def get_orbit_calculated_spatial_domains(
+            self,
+        ) -> list[OrbitCalculatedSpatialDomain]:
+            return super().get_orbit_calculated_spatial_domains() + [
+                {
+                    "OrbitNumber": 1234,
+                },
+            ]
+
+        def get_pge_version_class(self) -> PGEVersionClass:
+            return pge_version_class("TEST_PGE_NAME", "1.1.1.1")
+
+        def get_platform_name(self) -> str:
+            return "PLATFORM_NAME"
+
+        def get_producer_granule_id(self) -> str:
+            return self.get_granule_ur()
+
+        def get_production_date_time(self) -> datetime.datetime:
+            return datetime.datetime(2025, 1, 2)
+
+        def get_projects(self) -> list[Project]:
+            return super().get_projects() + [
+                {
+                    "ShortName": "PROJECT_1",
+                    "Campaigns": ["CAMPAIGN_1", "CAMPAIGN_1"],
+                },
+            ]
+
+        def get_related_url_builder(
+            self,
+            file: CMAGranuleFile,
+        ) -> Optional[RelatedUrlBuilder]:
+            bucket = file["bucket"]
+
+            if bucket.endswith("test_bucket"):
+                return TeaUrlBuilder(
+                    file,
+                    "https://example-distribution.123",
+                    "TEST/PATH",
+                )
+
+            return None
+
+        def get_reprocessing_actual(self) -> str:
+            return "TEST_REPROCESSING_ACTUAL"
+
+        def get_reprocessing_planned(self) -> str:
+            return "TEST_REPROCESSING_PLANNED"
+
+        def get_spatial_extent(self) -> SpatialExtent:
+            points = [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (7.0, 8.0)]
+            return {
+                "HorizontalSpatialDomain": {
+                    "Geometry": {
+                        "GPolygons": [
+                            {
+                                "Boundary": {
+                                    "Points": [
+                                        {
+                                            "Latitude": lat,
+                                            "Longitude": lon,
+                                        }
+                                        for lat, lon in points
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+            }
+
+        def get_tiling_identification_system(self) -> TilingIdentificationSystem:
+            return {
+                "TilingIdentificationSystemName": "TILING_IDENTIFICATION_SYSTEM_1",
+                "Coordinate1": {},
+                "Coordinate2": {},
+            }
+
+    ummg_obj = FullUmmg(granule)
+    ummg_obj.now = datetime.datetime(2025, 1, 1)
+
+    ummg_dict = ummg_obj.get_ummg()
+
+    assert ummg_dict == {
+        "AccessConstraints": {
+            "Value": 1,
+        },
+        "AdditionalAttributes": [
+            {
+                "Name": "TEST_ADDITIONAL_ATTRIBUTE",
+                "Values": ["TEST_VALUE"],
+            },
+            {
+                "Name": "TEST_ADDITIONAL_ATTRIBUTE_2",
+                "Values": ["TEST_VALUE_2"],
+            },
+        ],
+        "CloudCover": 0,
+        "CollectionReference": {
+            "ShortName": "TEST_CMR_SHORT_NAME",
+            "Version": "1",
+        },
+        "DataGranule": {
+            "ArchiveAndDistributionInformation": [
+                {
+                    "Name": "distribution.zip",
+                    "Size": 0.5,
+                    "SizeUnit": "MB",
+                    "Format": "Zip",
+                    "MimeType": "application/zip",
+                    "Checksum": {
+                        "Value": "00000000000000000000000000000000",
+                        "Algorithm": "MD5",
+                    },
+                    "Files": [
+                        {
+                            "Name": "test_file.txt",
+                            "SizeInBytes": 12345,
+                            "Format": "Text",
+                            "FormatType": "NA",
+                            "Checksum": {
+                                "Value": "00000000000000000000000000000000",
+                                "Algorithm": "MD5",
+                            },
+                        },
+                    ],
+                },
+            ],
+            "DayNightFlag": "Unspecified",
+            "Identifiers": [
+                {
+                    "IdentifierType": "ProducerGranuleId",
+                    "Identifier": "TEST_GRANULE_ID",
+                },
+                {
+                    "IdentifierType": "Other",
+                    "IdentifierName": "SASVersionId",
+                    "Identifier": "TEST_SAS_VERSION",
+                },
+            ],
+            "ProductionDateTime": "2025-01-02T00:00:00Z",
+            "ReprocessingActual": "TEST_REPROCESSING_ACTUAL",
+            "ReprocessingPlanned": "TEST_REPROCESSING_PLANNED",
+        },
+        "GranuleUR": "TEST_GRANULE_ID",
+        "GridMappingNames": ["GRID_MAPPING_NAME_1", "GRID_MAPPING_NAME_2"],
+        "InputGranules": ["INPUT_GRANULE_1", "INPUT_GRANULE_2"],
+        "MeasuredParameters": [
+            {
+                "ParameterName": "PARAM_1",
+            },
+            {
+                "ParameterName": "PARAM_2",
+                "QAStats": {},
+                "QAFlags": {},
+            },
+        ],
+        "MetadataSpecification": {
+            "Name": "UMM-G",
+            "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.6.5",
+            "Version": "1.6.5",
+        },
+        "NativeProjectionNames": [
+            "NATIVE_PROJECTION_NAME_1",
+            "NATIVE_PROJECTION_NAME_2",
+        ],
+        "OrbitCalculatedSpatialDomains": [
+            {
+                "OrbitNumber": 1234,
+            },
+        ],
+        "PGEVersionClass": {
+            "PGEName": "TEST_PGE_NAME",
+            "PGEVersion": "1.1.1.1",
+        },
+        "Platforms": [
+            {
+                "ShortName": "PLATFORM_NAME",
+                "Instruments": [
+                    {
+                        "ShortName": "INSTRUMENT_1",
+                        "Characteristics": [
+                            {
+                                "Name": "CHARACTERISTIC_1",
+                                "Value": "VALUE_1",
+                            },
+                        ],
+                        "ComposedOf": [
+                            {"ShortName": "INSTRUMENT_1-A"},
+                            {"ShortName": "INSTRUMENT_1-B"},
+                        ],
+                        "OperationalModes": ["OP1", "OP2"],
+                    },
+                ],
+            },
+        ],
+        "Projects": [
+            {
+                "ShortName": "PROJECT_1",
+                "Campaigns": ["CAMPAIGN_1", "CAMPAIGN_1"],
+            },
+        ],
+        "ProviderDates": [
+            {"Date": "2025-01-01T00:00:00Z", "Type": "Insert"},
+            {"Date": "2025-01-01T00:00:00Z", "Type": "Update"},
+        ],
+        "RelatedUrls": [
+            {
+                "URL": "https://example-distribution.123/TEST/PATH/test_prefix/test_file.txt",
+                "Type": "GET DATA",
+                "Description": "Download test_file.txt",
+            },
+            {
+                "URL": "s3://test_bucket/test_prefix/test_file.txt",
+                "Type": "GET DATA VIA DIRECT ACCESS",
+                "Description": (
+                    "This link provides direct download access via S3 to "
+                    "test_file.txt"
+                ),
+            },
+        ],
+        "SpatialExtent": {
+            "HorizontalSpatialDomain": {
+                "Geometry": {
+                    "GPolygons": [
+                        {
+                            "Boundary": {
+                                "Points": [
+                                    {
+                                        "Latitude": 1.0,
+                                        "Longitude": 2.0,
+                                    },
+                                    {
+                                        "Latitude": 3.0,
+                                        "Longitude": 4.0,
+                                    },
+                                    {
+                                        "Latitude": 5.0,
+                                        "Longitude": 6.0,
+                                    },
+                                    {
+                                        "Latitude": 7.0,
+                                        "Longitude": 8.0,
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+        "TemporalExtent": {
+            "RangeDateTime": {
+                "BeginningDateTime": "2024-01-01T00:00:00Z",
+                "EndingDateTime": "2024-01-02T00:00:00Z",
+            },
+        },
+        "TilingIdentificationSystem": {
+            "TilingIdentificationSystemName": "TILING_IDENTIFICATION_SYSTEM_1",
+            "Coordinate1": {},
+            "Coordinate2": {},
+        },
+    }
+
+
+def test_get_ummg_date_format_override(granule):
+    class CustomUmmg(LocalUmmgBase):
+        def get_umm_date_time_format(self) -> str:
+            return "%Y-%m-%dT%H:%M:%S.%fZ"
+
+    ummg_obj = CustomUmmg(granule)
+    ummg_obj.now = datetime.datetime(2025, 1, 1)
+
+    ummg_dict = ummg_obj.get_ummg()
+
+    assert ummg_dict == {
+        "CollectionReference": {
+            "ShortName": "TEST_CMR_SHORT_NAME",
+            "Version": "1",
+        },
+        "GranuleUR": "TEST_GRANULE_ID",
+        "MetadataSpecification": {
+            "Name": "UMM-G",
+            "URL": "https://cdn.earthdata.nasa.gov/umm/granule/v1.6.5",
+            "Version": "1.6.5",
+        },
+        "ProviderDates": [
+            {"Date": "2025-01-01T00:00:00.000000Z", "Type": "Insert"},
+            {"Date": "2025-01-01T00:00:00.000000Z", "Type": "Update"},
+        ],
+    }

--- a/tests/test_related_url_builder.py
+++ b/tests/test_related_url_builder.py
@@ -1,0 +1,28 @@
+from mandible.umm_classes import TeaUrlBuilder
+from mandible.umm_classes.types import CMAGranuleFile
+
+
+def test_tea_url_builder_no_type():
+    file: CMAGranuleFile = {
+        "fileName": "test.txt",
+        "bucket": "test_bucket",
+        "key": "test-prefix/test.txt",
+    }
+    builder = TeaUrlBuilder(
+        file,
+        "https://test-example.123/",
+        "FOO/TEST",
+    )
+
+    assert builder.get_related_urls() == [
+        {
+            "URL": "https://test-example.123/FOO/TEST/test-prefix/test.txt",
+            "Description": "Download test.txt",
+            "Type": "GET DATA",
+        },
+        {
+            "URL": "s3://test_bucket/test-prefix/test.txt",
+            "Description": "This link provides direct download access via S3 to test.txt",
+            "Type": "GET DATA VIA DIRECT ACCESS",
+        },
+    ]


### PR DESCRIPTION
Adds a stripped down version of our `UmmgBase` class to mandible. The idea is that the `UmmgBase` class has a `get_*` method for every possible UMM-G element. Elements that are required either get a default implementation if one makes sense or are marked as abstract methods. Workflows can define their own `WorkflowUmmgBase` subclasses to add additional workflow specific functionality to the base class.

Some optional elements that have nested fields also get a mixin class that can be used to pull in boilerplate `get_*` methods for sub elements. Some even provide a default implementation if that implementation was common enough in our workflows.

The idea for now is just to create a pretty bare bones starting point. There may be more functionality that is common enough to pull into mandible later. There is already a lot of code here because of the `TypedDict` definitions which give useful type hints and the large number of boilerplate `get_*` functions.