### PR TITLE
Update GranuleLocalities to be of type NotRequired[list[str]]

### DIFF
--- a/mandible/umm_classes/types.py
+++ b/mandible/umm_classes/types.py
@@ -315,8 +315,7 @@ class SpatialExtent(TypedDict):
 
     https://git.earthdata.nasa.gov/projects/EMFD/repos/unified-metadata-model/browse/granule/v1.6.5/umm-g-json-schema.json#465
     """
-    # TODO(reweeden): Implement
-    GranuleLocalities: NotRequired[list[dict[str, Any]]]
+    GranuleLocalities: NotRequired[list[str]]
     HorizontalSpatialDomain: NotRequired["HorizontalSpatialDomain"]
     # TODO(reweeden): Implement
     VerticalSpatialDomains: NotRequired[list[dict[str, Any]]]


### PR DESCRIPTION
I left the `NotRequired`, but I'm not sure why we're using it.