### PR TITLE
Typing improvements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,8 +34,10 @@ jobs:
 
       - run: |
           poetry run mypy \
+            --follow-untyped-imports \
+            --disallow-any-unimported \
+            --disallow-untyped-defs \
             --check-untyped-defs \
-            --disable-error-code=import-untyped \
             --strict-equality \
             --warn-redundant-casts \
             --warn-unused-ignores \

--- a/mandible/jsonpath.py
+++ b/mandible/jsonpath.py
@@ -2,7 +2,7 @@ try:
     import jsonpath_ng
     import jsonpath_ng.ext
 except ImportError:
-    jsonpath_ng = None
+    jsonpath_ng = None  # type: ignore
 
 
 def get(data: dict, path: str) -> list:

--- a/mandible/metadata_mapper/builder.py
+++ b/mandible/metadata_mapper/builder.py
@@ -78,14 +78,14 @@ class DirectiveBuilder(Builder):
         return truediv(other, self)
 
 
-T = TypeVar("T")
+F = TypeVar("F", bound=Callable[..., DirectiveBuilder])
 
 
-def _directive_builder(directive: type["TemplateDirective"]) -> Callable[[T], T]:
+def _directive_builder(directive: type["TemplateDirective"]) -> Callable[[F], F]:
     directive_name = directive.directive_name
     assert directive_name is not None
 
-    def decorator(func):
+    def decorator(func: F) -> F:
         func.__doc__ = directive.__doc__
 
         _DIRECTIVE_BUILDER_REGISTRY[directive_name] = func
@@ -98,7 +98,7 @@ def _directive_builder(directive: type["TemplateDirective"]) -> Callable[[T], T]
 def mapped(
     source: str,
     key: Key,
-    **key_options,
+    **key_options: Any,
 ) -> DirectiveBuilder:
     directive_name = Mapped.directive_name
     assert directive_name is not None
@@ -121,7 +121,7 @@ def reformatted(
     format: str,
     value: Any,
     key: Key,
-    **key_options,
+    **key_options: Any,
 ) -> DirectiveBuilder:
     directive_name = Reformatted.directive_name
     assert directive_name is not None
@@ -144,7 +144,11 @@ def reformatted(
 #
 
 
-def _binop_directive(directive_name: str, left: Any, right: Any):
+def _binop_directive(
+    directive_name: str,
+    left: Any,
+    right: Any,
+) -> DirectiveBuilder:
     return DirectiveBuilder(
         directive_name,
         {

--- a/mandible/metadata_mapper/directive/directive.py
+++ b/mandible/metadata_mapper/directive/directive.py
@@ -1,16 +1,21 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import ClassVar, Optional
+from typing import Any, ClassVar, Optional
 
 from mandible.metadata_mapper.context import Context
 from mandible.metadata_mapper.key import Key
 from mandible.metadata_mapper.source import Source
 from mandible.metadata_mapper.types import Key as KeyType
+from mandible.metadata_mapper.types import Template
 
 DIRECTIVE_REGISTRY: dict[str, type["TemplateDirective"]] = {}
 
 
-def get_key(key: KeyType, context: Context, key_options: dict) -> Key:
+def get_key(
+    key: KeyType,
+    context: Context,
+    key_options: dict[str, Any],
+) -> Key:
     if callable(key):
         key = key(context)
 
@@ -29,8 +34,8 @@ class TemplateDirective(ABC):
         cls,
         register: bool = True,
         name: Optional[str] = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         if register:
             name = name or cls.__name__.lower()
             DIRECTIVE_REGISTRY[name] = cls
@@ -45,8 +50,8 @@ class TemplateDirective(ABC):
     sources: dict[str, Source]
 
     @abstractmethod
-    def call(self):
+    def call(self) -> Template:
         pass
 
-    def prepare(self):
+    def prepare(self) -> None:
         pass

--- a/mandible/metadata_mapper/directive/mapped.py
+++ b/mandible/metadata_mapper/directive/mapped.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 
 from mandible.metadata_mapper.exception import MetadataMapperError
-from mandible.metadata_mapper.types import Key
+from mandible.metadata_mapper.types import Key, Template
 
 from .directive import TemplateDirective, get_key
 
@@ -18,15 +18,15 @@ class Mapped(TemplateDirective):
     key: Key
     key_options: dict = field(default_factory=dict)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.source not in self.sources:
             raise MetadataMapperError(f"source {repr(self.source)} does not exist")
 
         self.source_obj = self.sources[self.source]
         self.key_obj = get_key(self.key, self.context, self.key_options)
 
-    def call(self):
+    def call(self) -> Template:
         return self.source_obj.get_value(self.key_obj)
 
-    def prepare(self):
+    def prepare(self) -> None:
         self.source_obj.add_key(self.key_obj)

--- a/mandible/metadata_mapper/directive/reformatted.py
+++ b/mandible/metadata_mapper/directive/reformatted.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from mandible.metadata_mapper.exception import MetadataMapperError
 from mandible.metadata_mapper.format import FORMAT_REGISTRY
-from mandible.metadata_mapper.types import Key
+from mandible.metadata_mapper.types import Key, Template
 
 from .directive import TemplateDirective, get_key
 
@@ -22,7 +22,7 @@ class Reformatted(TemplateDirective):
     key: Key
     key_options: dict = field(default_factory=dict)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         format_cls = FORMAT_REGISTRY.get(self.format)
         if format_cls is None:
             raise MetadataMapperError(f"format {repr(self.format)} does not exist")
@@ -30,7 +30,7 @@ class Reformatted(TemplateDirective):
         self.format_obj = format_cls()
         self.key_obj = get_key(self.key, self.context, self.key_options)
 
-    def call(self):
+    def call(self) -> Template:
         if isinstance(self.value, bytes):
             value = self.value
         elif isinstance(self.value, str):

--- a/mandible/metadata_mapper/format/format.py
+++ b/mandible/metadata_mapper/format/format.py
@@ -18,7 +18,7 @@ class FormatError(Exception):
     def __init__(self, reason: str):
         self.reason = reason
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.reason
 
 
@@ -28,7 +28,7 @@ FORMAT_REGISTRY: dict[str, type["Format"]] = {}
 @dataclass
 class Format(ABC):
     # Registry boilerplate
-    def __init_subclass__(cls, register: bool = True, **kwargs):
+    def __init_subclass__(cls, register: bool = True, **kwargs: Any) -> None:
         if register:
             FORMAT_REGISTRY[cls.__name__] = cls
 
@@ -134,34 +134,34 @@ class _PlaceholderBase(FileFormat[None], register=False):
         raise RuntimeError("Unreachable!")
 
     @staticmethod
-    def eval_key(data: None, key: Key):
+    def eval_key(data: None, key: Key) -> Any:
         # __init__ always raises
         raise RuntimeError("Unreachable!")
 
 
 @dataclass
 class H5(_PlaceholderBase):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("h5py")
 
 
 @dataclass
 class Xml(_PlaceholderBase):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("lxml")
 
 
 # Define formats that don't require extra dependencies
 
 @dataclass
-class Json(FileFormat[dict]):
+class Json(FileFormat[dict[str, Any]]):
     @staticmethod
     @contextlib.contextmanager
-    def parse_data(file: IO[bytes]) -> Generator[dict]:
+    def parse_data(file: IO[bytes]) -> Generator[dict[str, Any]]:
         yield json.load(file)
 
     @staticmethod
-    def eval_key(data: dict, key: Key):
+    def eval_key(data: dict[str, Any], key: Key) -> Any:
         values = jsonpath.get(data, key.key)
 
         return key.resolve_list_match(values)
@@ -179,7 +179,7 @@ class ZipMember(Format):
     """Filter against any attributes of zipfile.ZipInfo objects"""
     format: Format
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._compiled_filters = {
             k: re.compile(v) if isinstance(v, str) else v
             for k, v in self.filters.items()

--- a/mandible/metadata_mapper/format/xml.py
+++ b/mandible/metadata_mapper/format/xml.py
@@ -35,7 +35,9 @@ class Xml(FileFormat[etree._ElementTree]):
         return xpath_result
 
 
-def convert_result(result: Union[etree._Element, int, str, bytes, tuple]):
+def convert_result(
+    result: Union[etree._Element, int, str, bytes, tuple],
+) -> Union[None, int, str, bytes]:
     if isinstance(result, etree._Element):
         return result.text
     if isinstance(result, (int, str, bytes)):

--- a/mandible/metadata_mapper/key.py
+++ b/mandible/metadata_mapper/key.py
@@ -14,7 +14,7 @@ class Key:
     return_first: bool = False
     default: Any = RAISE_EXCEPTION
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.return_list and self.return_first:
             raise ValueError(
                 "cannot set both 'return_list' and 'return_first' to True",

--- a/mandible/metadata_mapper/mapper.py
+++ b/mandible/metadata_mapper/mapper.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from collections.abc import Generator
 from typing import Any, Optional
 
 from .context import Context, replace_context_values
@@ -69,7 +70,11 @@ class MetadataMapper:
                 f"failed to evaluate template: {e}",
             ) from e
 
-    def _prepare_directives(self, context: Context, sources: dict[str, Source]):
+    def _prepare_directives(
+        self,
+        context: Context,
+        sources: dict[str, Source],
+    ) -> None:
         for value, debug_path in _walk_values(self.template):
             if isinstance(value, dict):
                 directive_config = self._get_directive_name(value, debug_path)
@@ -227,7 +232,7 @@ class MetadataMapper:
             raise TemplateError(str(e), debug_path) from e
 
 
-def _walk_values(obj: Any, debug_path: str = "$"):
+def _walk_values(obj: Any, debug_path: str = "$") -> Generator[tuple[Any, str]]:
     yield obj, debug_path
     if isinstance(obj, dict):
         for key, val in obj.items():

--- a/mandible/metadata_mapper/source.py
+++ b/mandible/metadata_mapper/source.py
@@ -17,25 +17,25 @@ SOURCE_REGISTRY: dict[str, type["Source"]] = {}
 @dataclass
 class Source(ABC):
     # Registry boilerplate
-    def __init_subclass__(cls, register: bool = True, **kwargs):
+    def __init_subclass__(cls, register: bool = True, **kwargs: Any) -> None:
         if register:
             SOURCE_REGISTRY[cls.__name__] = cls
 
         super().__init_subclass__(**kwargs)
 
     # Begin class definition
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._keys: set[Key] = set()
         self._values: dict[Key, Any] = {}
 
-    def add_key(self, key: Key):
+    def add_key(self, key: Key) -> None:
         self._keys.add(key)
 
     @abstractmethod
-    def query_all_values(self, context: Context):
+    def query_all_values(self, context: Context) -> None:
         pass
 
-    def get_value(self, key: Key):
+    def get_value(self, key: Key) -> Any:
         return self._values[key]
 
 
@@ -44,7 +44,7 @@ class FileSource(Source):
     storage: Storage
     format: Format
 
-    def query_all_values(self, context: Context):
+    def query_all_values(self, context: Context) -> None:
         if not self._keys:
             return
 

--- a/mandible/metadata_mapper/storage/cmr_query.py
+++ b/mandible/metadata_mapper/storage/cmr_query.py
@@ -18,7 +18,7 @@ class CmrQuery(HttpRequest):
     format: str = ""
     token: Optional[str] = None
 
-    def __post_init__(self, url: Optional[str]):
+    def __post_init__(self, url: Optional[str]) -> None:
         if url:
             raise ValueError(
                 "do not set 'url' directly, use 'base_url' and 'path' instead",

--- a/mandible/metadata_mapper/storage/storage.py
+++ b/mandible/metadata_mapper/storage/storage.py
@@ -18,7 +18,7 @@ STORAGE_REGISTRY: dict[str, type["Storage"]] = {}
 
 class Storage(ABC):
     # Registry boilerplate
-    def __init_subclass__(cls, register: bool = True, **kwargs):
+    def __init_subclass__(cls, register: bool = True, **kwargs: Any) -> None:
         if register:
             STORAGE_REGISTRY[cls.__name__] = cls
 
@@ -53,13 +53,13 @@ class _PlaceholderBase(Storage, register=False):
 
 @dataclass
 class HttpRequest(_PlaceholderBase):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("requests")
 
 
 @dataclass
 class CmrQuery(_PlaceholderBase):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("requests")
 
 
@@ -91,7 +91,7 @@ class FilteredStorage(Storage, register=False):
     # Begin class definition
     filters: dict[str, Any] = field(default_factory=dict)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._compiled_filters_cache: Optional[dict[str, Any]] = None
 
     @property

--- a/mandible/umm_classes/base.py
+++ b/mandible/umm_classes/base.py
@@ -73,7 +73,7 @@ class UmmgBase(ABC):
     def date_to_str(self, date: None) -> None:
         ...
 
-    def date_to_str(self, date):
+    def date_to_str(self, date: Optional[datetime.date]) -> Optional[str]:
         """Serialize a datetime.date or datetime.datetime as a string using the
         format expected by UMM-G.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.9.4"
+version = "0.9.5"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"


### PR DESCRIPTION
Adding `--disallow-untyped-defs` to ensure that all definitions are fully typed.

<details>
<summary>Pull Request Checklist</summary>

I have:
- [x] performed a self review of my code [I&A code style](https://github.com/asfadmin/ia-standards/blob/main/standards.md)
    - Resources and Data Structures are sorted by ABC or a defined sorting pattern
- [x] updated the documentation accordingly
- [x] verified required action checks are passing
- [x] bumped the version number as appropriate
</details>