### PR TITLE
Rename `record_builder` parameter to `extra_factory`

### DIFF
--- a/mandible/log.py
+++ b/mandible/log.py
@@ -36,7 +36,7 @@ def _build_cumulus_extras_from_cma(event: _Event) -> dict[str, Any]:
 
 def init_custom_log_record_factory(
     event: _Event,
-    record_builder: _ExtraFactory = _build_cumulus_extras_from_cma,
+    extra_factory: _ExtraFactory = _build_cumulus_extras_from_cma,
 ) -> None:
     """Configures the logging record factory and can be overwritten by providing
     a function that takes the event dict as an input and returns a dict of log
@@ -51,13 +51,13 @@ def init_custom_log_record_factory(
         "workflow_execution_name": event.get("cumulus_meta", {}).get("execution_name"),
     }
     """
-    extra = record_builder(event)
-    original_factory = logging.getLogRecordFactory()
+    extra = extra_factory(event)
+    original_record_factory = logging.getLogRecordFactory()
 
-    if isinstance(original_factory, LogRecordFactory):
-        original_factory.extra = extra
+    if isinstance(original_record_factory, LogRecordFactory):
+        original_record_factory.extra = extra
     else:
-        record_factory = LogRecordFactory(original_factory, extra)
+        record_factory = LogRecordFactory(original_record_factory, extra)
         logging.setLogRecordFactory(record_factory)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.9.5"
+version = "0.10.0"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"


### PR DESCRIPTION
The name old name was a little misleading since in the logging module 'record' would be assumed to mean `LogRecord`, which is not the case here. There is a separate class for creating the `LogRecord`.

<details>
<summary>Pull Request Checklist</summary>

I have:
- [x] performed a self review of my code [I&A code style](https://github.com/asfadmin/ia-standards/blob/main/standards.md)
    - Resources and Data Structures are sorted by ABC or a defined sorting pattern
- [x] updated the documentation accordingly
- [x] verified required action checks are passing
- [x] bumped the version number as appropriate
</details>