### PR TITLE
Correct JSON typing and support

### DIFF
--- a/mandible/jsonpath.py
+++ b/mandible/jsonpath.py
@@ -1,3 +1,5 @@
+import re
+from collections.abc import Generator
 from typing import Union
 
 try:
@@ -19,17 +21,39 @@ JsonValue = Union[
     dict[str, "JsonValue"],
     list["JsonValue"],
 ]
+
+BRACKET_PATTERN = re.compile(r"\[(.*)\]$")
+
+
 def get(data: JsonValue, path: str) -> list[JsonValue]:
     # Fall back to simple dot paths
     if jsonpath_ng is None:
-        val = data
-        for part in path.split("."):
-            if part == "$":
-                continue
-
-            val = val[part]
-
-        return [val]
+        return _get_dot_path(data, path)
 
     expr = jsonpath_ng.ext.parse(path)
     return [match.value for match in expr.find(data)]
+
+
+def _get_dot_path(data: JsonValue, path: str) -> list[JsonValue]:
+    val = data
+    for part in _parse_dot_path(path):
+        if part == "$":
+            continue
+
+        if isinstance(val, dict):
+            val = val[part]
+        elif isinstance(val, list):
+            val = val[int(part)]
+        else:
+            raise KeyError(path)
+
+    return [val]
+
+
+def _parse_dot_path(path: str) -> Generator[str]:
+    for part in path.split("."):
+        if (m := BRACKET_PATTERN.search(part)):
+            yield part[:m.start()]
+            yield m.group(1)
+        else:
+            yield part

--- a/mandible/jsonpath.py
+++ b/mandible/jsonpath.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 try:
     import jsonpath_ng
     import jsonpath_ng.ext
@@ -5,7 +7,19 @@ except ImportError:
     jsonpath_ng = None  # type: ignore
 
 
-def get(data: dict, path: str) -> list:
+JsonValue = Union[
+    # Primitives
+    bool,
+    float,
+    int,
+    str,
+    # Special constants
+    None,
+    # Nested structures
+    dict[str, "JsonValue"],
+    list["JsonValue"],
+]
+def get(data: JsonValue, path: str) -> list[JsonValue]:
     # Fall back to simple dot paths
     if jsonpath_ng is None:
         val = data

--- a/mandible/metadata_mapper/format/format.py
+++ b/mandible/metadata_mapper/format/format.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import IO, Any, Generic, TypeVar
 
 from mandible import jsonpath
+from mandible.jsonpath import JsonValue
 from mandible.metadata_mapper.key import RAISE_EXCEPTION, Key
 
 T = TypeVar("T")
@@ -154,14 +155,14 @@ class Xml(_PlaceholderBase):
 # Define formats that don't require extra dependencies
 
 @dataclass
-class Json(FileFormat[dict[str, Any]]):
+class Json(FileFormat[JsonValue]):
     @staticmethod
     @contextlib.contextmanager
-    def parse_data(file: IO[bytes]) -> Generator[dict[str, Any]]:
+    def parse_data(file: IO[bytes]) -> Generator[JsonValue]:
         yield json.load(file)
 
     @staticmethod
-    def eval_key(data: dict[str, Any], key: Key) -> Any:
+    def eval_key(data: JsonValue, key: Key) -> JsonValue:
         values = jsonpath.get(data, key.key)
 
         return key.resolve_list_match(values)

--- a/mandible/metadata_mapper/format/format.py
+++ b/mandible/metadata_mapper/format/format.py
@@ -119,9 +119,8 @@ class FileFormat(Format, Generic[T], ABC, register=False):
 
 @dataclass
 class _PlaceholderBase(FileFormat[None], register=False):
-    """
-    Base class for defining placeholder implementations for classes that
-    require extra dependencies to be installed
+    """Base class for defining placeholder implementations for classes that
+    require extra dependencies to be installed.
     """
     def __init__(self, dep: str):
         raise Exception(
@@ -156,6 +155,21 @@ class Xml(_PlaceholderBase):
 
 @dataclass
 class Json(FileFormat[JsonValue]):
+    """A Format for querying Json files.
+
+    When `jsonpath_ng` is installed, `jsonpath_ng.ext.parse` will be used to
+    evaluate keys using extended JSONPath functionality.
+    ```
+    $.inventory[?name = 'Banana'].price
+    ```
+
+    When `jsonpath_ng` is NOT installed, only limited use of `.` and `[]` syntax
+    is supported.
+    ```
+    $.inventory[3].price
+    ```
+    """
+
     @staticmethod
     @contextlib.contextmanager
     def parse_data(file: IO[bytes]) -> Generator[JsonValue]:

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -159,12 +159,44 @@ def test_json_optional_key():
     assert format.get_value(file, Key("bar", default=bar_value)) == bar_value
 
 
+def test_json_list():
+    file = io.BytesIO(b"""
+    [
+        "foo",
+        "bar",
+        "baz"
+    ]
+    """)
+    format = Json()
+
+    assert format.get_value(file, Key("$")) == ["foo", "bar", "baz"]
+    file.seek(0)
+    assert format.get_value(file, Key("$[1]")) == "bar"
+
+
+def test_json_primitive():
+    format = Json()
+
+    assert format.get_value(io.BytesIO(b"10"), Key("$")) == 10
+    assert format.get_value(io.BytesIO(b"true"), Key("$")) is True
+    assert format.get_value(io.BytesIO(b"null"), Key("$")) is None
+    assert format.get_value(io.BytesIO(b'"foo"'), Key("$")) == "foo"
+
+
 def test_json_key_error():
     file = io.BytesIO(b"{}")
     format = Json()
 
     with pytest.raises(FormatError, match="key not found 'foo'"):
         format.get_values(file, [Key("foo")])
+
+
+def test_json_key_error_primitive():
+    file = io.BytesIO(b'{"foo": 10}')
+    format = Json()
+
+    with pytest.raises(FormatError, match="key not found 'foo.bar'"):
+        format.get_values(file, [Key("foo.bar")])
 
 
 def test_zip():


### PR DESCRIPTION
Our type annotations and 'basic' querying functionality were assuming that parsed JSON documents would always start with a top level dict. This updates the annotations to allow any valid JSON document including ones that have a top level list or are simply a single primitive value. I also implemented a basic `[]` syntax to support list indexing when `jsonpath_ng` is not installed.

<details>
<summary>Pull Request Checklist</summary>

I have:
- [x] performed a self review of my code [I&A code style](https://github.com/asfadmin/ia-standards/blob/main/standards.md)
    - Resources and Data Structures are sorted by ABC or a defined sorting pattern
- [x] updated the documentation accordingly
- [x] verified required action checks are passing
- [x] bumped the version number as appropriate
</details>