### PR TITLE
PR-7034 Fix h5py array conversion

### DIFF
--- a/mandible/metadata_mapper/format/h5.py
+++ b/mandible/metadata_mapper/format/h5.py
@@ -29,9 +29,10 @@ def normalize(node_val: Any) -> Any:
     if isinstance(node_val, np.floating):
         return float(node_val)
     if isinstance(node_val, np.ndarray):
-        value = node_val.tolist()
-        if isinstance(value[0], bytes):
-            value = [x.decode("utf-8") for x in value]
+        value = [
+            x.decode("utf-8") if isinstance(x, bytes) else x
+            for x in node_val.tolist()
+        ]
         return value
     if isinstance(node_val, bytes):
         return node_val.decode("utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.10.0"
+version = "0.10.1"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"

--- a/tests/test_h5.py
+++ b/tests/test_h5.py
@@ -1,0 +1,25 @@
+import pytest
+
+pytestmark = pytest.mark.h5
+
+
+def test_normalize():
+    # Importing inside of the test since the imports might fail if h5py is not
+    # installed. Pytest will ensure the tests are not run in that case by using
+    # the pytest mark.
+    import numpy as np
+
+    from mandible.metadata_mapper.format.h5 import normalize
+
+    assert normalize(np.bool_(True)) is True
+    assert normalize(np.bool_(False)) is False
+    assert normalize(np.int64(10)) == 10
+    assert normalize(np.float64(123.45)) == 123.45
+    assert normalize(np.str_("foo")) == "foo"
+    assert normalize(np.bytes_(b"foo")) == "foo"
+    assert normalize(np.array([True, False], dtype=np.bool_)) == [True, False]
+    assert normalize(np.array([1, 2], dtype=np.int64)) == [1, 2]
+    assert normalize(np.array([1.2, 2.3], dtype=np.float64)) == [1.2, 2.3]
+    assert normalize(np.array(["A", "B"], dtype="|S1")) == ["A", "B"]
+    assert normalize(np.array(["A", "B"], dtype="O")) == ["A", "B"]
+    assert normalize(np.array([], dtype="|S1")) == []


### PR DESCRIPTION
L0B RRSD error revealed the following root cause:

```
Traceback (most recent call last):
  File "/home/cloudshell-user/h5env/lib64/python3.9/site-packages/mandible/metadata_mapper/format/format.py", line 83, in _eval_key_wrapper
    return self.eval_key(data, key)
  File "/home/cloudshell-user/h5env/lib64/python3.9/site-packages/mandible/metadata_mapper/format/h5.py", line 21, in eval_key
    return normalize(data[key.key][()])
  File "/home/cloudshell-user/h5env/lib64/python3.9/site-packages/mandible/metadata_mapper/format/h5.py", line 33, in normalize
    if isinstance(value[0], bytes):
IndexError: list index out of range
```

There was an issue in the product that one of the h5 values was an empty list, which exposed a flaw in our numpy -> python `normalize` function which was crashing when passed an empty list.

This also adds a unit test to test the `normalize` function so we can test these edge cases directly.

This PR is not a blocker to fixing PR-7034 as the ultimate bug was an issue with the product that SDS is sending us that needs to be fixed on their side.

<details>
<summary>Pull Request Checklist</summary>

I have:
- [x] performed a self review of my code [I&A code style](https://github.com/asfadmin/ia-standards/blob/main/standards.md)
    - Resources and Data Structures are sorted by ABC or a defined sorting pattern
- [x] updated the documentation accordingly
- [x] verified required action checks are passing
- [x] bumped the version number as appropriate
</details>