### PR TITLE
Add provider to default log extra_factory

### DIFF
--- a/mandible/log.py
+++ b/mandible/log.py
@@ -30,6 +30,7 @@ def _build_cumulus_extras_from_cma(event: _Event) -> dict[str, Any]:
         "cirrus_core_version": os.getenv("CORE_VERSION"),
         "cumulus_version": event.get("cumulus_meta", {}).get("cumulus_version"),
         "granule_name": event.get("payload", {}).get("granules", [{}])[0].get("granuleId"),
+        "provider": event.get("meta", {}).get("provider", {}).get("id"),
         "workflow_execution_name": event.get("cumulus_meta", {}).get("execution_name"),
     }
 
@@ -48,6 +49,7 @@ def init_custom_log_record_factory(
         "cirrus_core_version": os.getenv("CORE_VERSION"),
         "cumulus_version": event.get("cumulus_meta", {}).get("cumulus_version"),
         "granule_name": event.get("payload", {}).get("granules", [{}])[0].get("granuleId"),
+        "provider": event.get("meta", {}).get("provider", {}).get("id"),
         "workflow_execution_name": event.get("cumulus_meta", {}).get("execution_name"),
     }
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.10.1"
+version = "0.10.2"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"


### PR DESCRIPTION
Example log message:
```
{
    "timestamp": "2025-09-11T17:06:42Z",
    "level": "INFO",
    "message": "Resizing OPERA_L3_DISP-S1_IW_F01093_VV_20201221T004213Z_20210619T004215Z_v1.0_20250418T131935Z_BROWSE.png from (2471, 2048) to (100, 82)",
    "logger": "generate_browse",
    "requestId": "d4e16d84-8799-4083-9c51-d2246b2df5bb",
    "cirrus_daac_version": "10e2669",
    "cirrus_core_version": "v20.1.1.1",
    "cumulus_version": "20.1.1",
    "granule_name": "OPERA_L3_DISP-S1_IW_F01093_VV_20201221T004213Z_20210619T004215Z_v1.0_20250418T131935Z",
    "provider": "ASFDAAC",
    "workflow_execution_name": "001dae41-c942-4441-9f15-ec974541c33a"
}
```

<details>
<summary>Pull Request Checklist</summary>

I have:
- [x] performed a self review of my code [I&A code style](https://github.com/asfadmin/ia-standards/blob/main/standards.md)
    - Resources and Data Structures are sorted by ABC or a defined sorting pattern
- [x] updated the documentation accordingly
- [x] verified required action checks are passing
- [x] bumped the version number as appropriate
</details>