### PR TITLE
PR-7242 Update supported Python versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - uses: TrueBrain/actions-flake8@v2
         with:
           flake8_version: 6.0.0
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - run: |
           pip install poetry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,13 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox~=4.0 tox-gh-actions~=3.0
-    - run: tox
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox~=4.0 tox-gh-actions~=3.0
+      - run: tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "poetry.core.masonry.api"
 
 
 [tool.poetry.dependencies]
-python = ">=3.9"
+python = ">=3.10"
 
 # Required
 typing-extensions = "^4.12.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mandible"
-version = "0.10.2"
+version = "0.10.3"
 description = "A generic framework for writing satellite data ingest systems"
 authors = ["Rohan Weeden <reweeden@alaska.edu>", "Matt Perry <mperry37@alaska.edu>"]
 license = "APACHE-2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ typing-extensions = "^4.12.2"
 # Optional
 h5py = { version = "^3.6.0", optional = true }
 jsonpath-ng = { version = "^1.4.0", optional = true }
-lxml = { version = "^4.9.2", optional = true }
+lxml = { version = ">=4.9.2,<7.0.0", optional = true }
 # Numpy is pinned to a minimum version by h5py. Unpinning here means our
 # requirements will always match those of h5py.
 numpy = { version = "*", optional = true }

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,6 +1,7 @@
 import bz2
 import io
 import json
+import sys
 import zipfile
 from unittest import mock
 
@@ -339,7 +340,9 @@ def test_zipinfo_jsonpath():
     format = ZipInfo()
 
     assert format.get_value(file, Key("infolist[1].compress_size")) == 21
-    assert format.get_value(file, Key("infolist[1]")) == {
+    infolist_item = format.get_value(file, Key("infolist[1]"))
+
+    expected = {
         "CRC": 3800794396,
         "comment": b"",
         "compress_size": 21,
@@ -359,6 +362,11 @@ def test_zipinfo_jsonpath():
         "reserved": 0,
         "volume": 0,
     }
+
+    if sys.version_info >= (3, 13, 0):
+        expected["compress_level"] = None
+
+    assert infolist_item == expected
 
 
 @pytest.mark.xml

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,15 @@
 requires =
     tox>4
 isolated_build = true
-env_list = py{39,310,311,312}-X{all,none}, py39-Xall-jp{14,15,16}
+env_list = py{310,311,312,313,314}-X{all,none}, py310-Xall-jp{14,15,16}
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [testenv]
 allowlist_externals = poetry


### PR DESCRIPTION
Will need to update the required checks in the repo settings.

Had to allow newer versions of lxml for 3.13 and 3.14 support. The API's we're using don't seem to have changed so I'm allowing the full range of lxml versions in the constraints.

Python 3.13 added a `compress_level` field to `ZipInfo` objects, so the unit test for that had to be updated.

<details>
<summary>Pull Request Checklist</summary>

I have:
- [x] performed a self review of my code [I&A code style](https://github.com/asfadmin/ia-standards/blob/main/standards.md)
    - Resources and Data Structures are sorted by ABC or a defined sorting pattern
- [x] updated the documentation accordingly
- [x] verified required action checks are passing
- [x] bumped the version number as appropriate
</details>