### PR TITLE
Force all additional_attributes to str, since CMR only accepts str

### DIFF
--- a/mandible/umm_classes/factory.py
+++ b/mandible/umm_classes/factory.py
@@ -30,7 +30,7 @@ from .types import (
 def additional_attribute(name: str, *value: str) -> AdditionalAttribute:
     return {
         "Name": name,
-        "Values": list(value),
+        "Values": [str(val) for val in value],
     }
 
 


### PR DESCRIPTION
## Pull Request Checklist

I have:
- [x] performed a self review of my code [I&A code style](https://github.com/asfadmin/ia-standards/blob/main/standards.md)
    - Resources and Data Structures are sorted by ABC or a defined sorting pattern
- [ ] updated the documentation accordingly
- [x] verified required action checks are passing
- [ ] bumped the version number as appropriate
